### PR TITLE
Remove unused variable from form

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -101,7 +101,6 @@ class FileAdoptionForm extends ConfigFormBase {
 
     $public_path = \Drupal::service('file_system')->realpath('public://');
     $preview = [];
-    $skipped = [];
 
     if ($public_path && is_dir($public_path)) {
       $entries = scandir($public_path);


### PR DESCRIPTION
## Summary
- tidy code by dropping an unused `$skipped` variable in `FileAdoptionForm`

## Testing
- `php -l src/Form/FileAdoptionForm.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ec844d048331906bfe7166aa036d