### PR TITLE
Fix Html escape callback in FileAdoptionForm

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -222,8 +222,8 @@ class FileAdoptionForm extends ConfigFormBase {
 
     $scan_results = $form_state->get('scan_results');
     if (!empty($scan_results)) {
-      $managed_list = array_map('Html::escape', $scan_results['to_manage']);
-      $media_list = array_map('Html::escape', $scan_results['to_media']);
+      $managed_list = array_map([Html::class, 'escape'], $scan_results['to_manage']);
+      $media_list = array_map([Html::class, 'escape'], $scan_results['to_media']);
 
       $form['results_manage'] = [
         '#type' => 'details',


### PR DESCRIPTION
## Summary
- fix invalid callback when mapping Html::escape

## Testing
- `php -l src/Form/FileAdoptionForm.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853085cc0008331af96178bc84a57fe