### PR TITLE
Fix media reference detection

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -362,6 +362,7 @@ class FileScanner {
         $query->join('file_usage', 'fu', 'fu.fid = fm.fid');
         $query->addField('fu', 'fid');
         $query->condition('fm.uri', $uri);
+        $query->condition('fu.type', 'media');
         $query->range(0, 1);
         return (bool) $query->execute()->fetchField();
     }


### PR DESCRIPTION
## Summary
- update media reference detection logic to ignore the `module` column
- ensure only `media` usages trigger a match

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532ca459448331a718d3220da7b733