### PR TITLE
Inject module handler into FileScanner

### DIFF
--- a/file_adoption.services.yml
+++ b/file_adoption.services.yml
@@ -6,3 +6,4 @@ services:
       - '@database'
       - '@config.factory'
       - '@logger.channel.default'
+      - '@module_handler'


### PR DESCRIPTION
## Summary
- inject `ModuleHandlerInterface` into `FileScanner`
- update service definition to pass `@module_handler`
- use `$this->moduleHandler` instead of `\Drupal::service('module_handler')`

## Testing
- `php` was not available, so no linting or unit tests were run

------
https://chatgpt.com/codex/tasks/task_e_6853314e90f88331a3c1e0b37dc38313