### PR TITLE
Add kernel tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # file_adoption
+
+## Running Tests
+
+1. Install development dependencies using Composer:
+   ```bash
+   composer install --dev
+   ```
+2. Execute PHPUnit from the module directory:
+   ```bash
+   vendor/bin/phpunit
+   ```
+
+The tests are located under the `tests/` directory and include kernel tests for the `FileScanner` service and the configuration form.

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\Tests\file_adoption\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\file_adoption\Form\FileAdoptionForm;
+use Drupal\Core\Form\FormState;
+
+/**
+ * Tests the FileAdoptionForm behavior.
+ *
+ * @group file_adoption
+ */
+class FileAdoptionFormTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'file', 'file_adoption'];
+
+  /**
+   * Tests scanning action in the form submit handler.
+   */
+  public function testFormScan() {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save();
+
+    file_put_contents("$public/example.txt", 'foo');
+
+    $this->config('file_adoption.settings')->set('ignore_patterns', '')->save();
+
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setTriggeringElement(['#name' => 'scan']);
+
+    $form_object = new FileAdoptionForm($this->container->get('file_adoption.file_scanner'), $this->container->get('module_handler'));
+    $form_object->submitForm($form, $form_state);
+
+    $results = $form_state->get('scan_results');
+    $this->assertEquals(['public://example.txt'], $results['to_manage']);
+  }
+
+}

--- a/tests/src/Kernel/FileScannerTest.php
+++ b/tests/src/Kernel/FileScannerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\Tests\file_adoption\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\file_adoption\FileScanner;
+
+/**
+ * Tests the FileScanner service.
+ *
+ * @group file_adoption
+ */
+class FileScannerTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'file', 'file_adoption'];
+
+  /**
+   * Tests ignore pattern parsing and scanning lists.
+   */
+  public function testScanning() {
+    // Point the public files directory to a temporary location.
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save();
+
+    // Create files and directories.
+    mkdir("$public/css", 0777, TRUE);
+    file_put_contents("$public/example.txt", 'foo');
+    file_put_contents("$public/css/skip.txt", 'bar');
+
+    // Configure ignore patterns.
+    $this->config('file_adoption.settings')->set('ignore_patterns', "css/*")->save();
+
+    /** @var \Drupal\file_adoption\FileScanner $scanner */
+    $scanner = $this->container->get('file_adoption.file_scanner');
+
+    $patterns = $scanner->getIgnorePatterns();
+    $this->assertEquals(['css/*'], $patterns);
+
+    $results = $scanner->scanWithLists();
+    $this->assertEquals(2, $results['files']);
+    $this->assertEquals(['public://example.txt'], $results['to_manage']);
+  }
+
+}


### PR DESCRIPTION
## Summary
- add kernel tests for FileScanner and the config form
- document running the tests in README

## Testing
- `phpunit` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853317313fc8331a7ade38c0fa976df