### PR TITLE
Fix missing logger channel service

### DIFF
--- a/file_adoption.services.yml
+++ b/file_adoption.services.yml
@@ -1,4 +1,8 @@
 services:
+  logger.channel.file_adoption:
+    class: Drupal\Core\Logger\LoggerChannel
+    factory: ['@logger.factory', get]
+    arguments: ['file_adoption']
   file_adoption.file_scanner:
     class: 'Drupal\file_adoption\FileScanner'
     arguments:


### PR DESCRIPTION
## Summary
- define `logger.channel.file_adoption` service so the FileScanner can log

## Testing
- `phpunit tests` *(fails: Class `Drupal\KernelTests\KernelTestBase` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854329d2e1c8331901aba69598ac331