### PR TITLE
Fix media entity duplication detection

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -362,7 +362,7 @@ class FileScanner {
         $query->join('file_usage', 'fu', 'fu.fid = fm.fid');
         $query->addField('fu', 'fid');
         $query->condition('fm.uri', $uri);
-        $query->condition('fu.type', 'media');
+        $query->condition('fu.module', 'media');
         $query->range(0, 1);
         return (bool) $query->execute()->fetchField();
     }


### PR DESCRIPTION
## Summary
- ensure isInMedia checks the `media` module in file usage

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685437aa51308331a78da40995da937d