### PR TITLE
Fix media detection query

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -362,11 +362,8 @@ class FileScanner {
         $query->join('file_usage', 'fu', 'fu.fid = fm.fid');
         $query->addField('fu', 'fid');
         $query->condition('fm.uri', $uri);
-        $query->condition(
-            $query->orConditionGroup()
-                ->condition('fu.module', 'media')
-                ->condition('fu.type', 'media')
-        );
+        $query->condition('fu.module', 'file');
+        $query->condition('fu.type', 'media');
         $query->range(0, 1);
         return (bool) $query->execute()->fetchField();
     }


### PR DESCRIPTION
## Summary
- update query in `isInMedia` to check module=`file` and type=`media`

## Testing
- `php /tmp/media_test/scan.php` shows no files when file is marked used
- `php /tmp/media_test/scan.php` shows `file2.txt` when missing usage
- `php /tmp/media_test/scan.php` shows no files after adding usage record

------
https://chatgpt.com/codex/tasks/task_e_6854dc20e0408331a5be773ddc087ddc