### PR TITLE
Handle empty file list

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -238,9 +238,11 @@ class FileAdoptionForm extends ConfigFormBase {
         '#title' => $this->t('Add to Managed Files (@count)', ['@count' => count($managed_list)]),
         '#open' => TRUE,
       ];
-      $form['results_manage']['list'] = [
-        '#markup' => Markup::create('<ul><li>' . implode('</li><li>', array_slice($managed_list, 0, 500)) . '</li></ul>'),
-      ];
+      if (!empty($managed_list)) {
+        $form['results_manage']['list'] = [
+          '#markup' => Markup::create('<ul><li>' . implode('</li><li>', array_slice($managed_list, 0, 500)) . '</li></ul>'),
+        ];
+      }
 
 
       $form['actions']['adopt'] = [


### PR DESCRIPTION
## Summary
- avoid rendering empty `<ul>`

## Testing
- `composer install --dev` *(fails: composer not found)*
- `vendor/bin/phpunit` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855774302548331835be0779254d370