### PR TITLE
Add items_per_run setting with schema and update hook

### DIFF
--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -8,3 +8,4 @@ ignore_patterns: |
   php/*
   styles/*
 enable_adoption: false
+items_per_run: 10

--- a/config/schema/file_adoption.schema.yml
+++ b/config/schema/file_adoption.schema.yml
@@ -8,3 +8,6 @@ file_adoption.settings:
     enable_adoption:
       type: boolean
       label: 'Enable Adoption'
+    items_per_run:
+      type: integer
+      label: 'Items processed per cron run'

--- a/file_adoption.install
+++ b/file_adoption.install
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Implements hook_update_N().
+ */
+function file_adoption_update_10001() {
+  $config = \Drupal::configFactory()->getEditable('file_adoption.settings');
+  if ($config->get('items_per_run') === NULL) {
+    $config->set('items_per_run', 10)->save();
+  }
+  return t('Added items_per_run setting.');
+}


### PR DESCRIPTION
## Summary
- extend default configuration with `items_per_run`
- document the new setting in the schema
- provide update hook to add the setting on existing sites

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6855891227788331b8fce56aac25b1ad