### PR TITLE
Implement file system injection and cron limit field

### DIFF
--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -33,7 +33,10 @@ class FileAdoptionFormTest extends KernelTestBase {
     $form_state = new FormState();
     $form_state->setTriggeringElement(['#name' => 'scan']);
 
-    $form_object = new FileAdoptionForm($this->container->get('file_adoption.file_scanner'));
+    $form_object = new FileAdoptionForm(
+      $this->container->get('file_adoption.file_scanner'),
+      $this->container->get('file_system')
+    );
     $form_object->submitForm($form, $form_state);
 
     $results = $form_state->get('scan_results');


### PR DESCRIPTION
## Summary
- inject the file system service into `FileAdoptionForm`
- add an "Items per cron run" numeric field
- store that field in configuration
- update Kernel test for new dependencies

## Testing
- `phpunit --version` *(fails: command not found)*
- `composer install` *(fails: command not found)*
- `curl -L -o phpunit.phar https://phar.phpunit.de/phpunit-9.phar` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_685589c0898483318b790cb00bdb3861