### PR TITLE
Implement adoption limit for cron

### DIFF
--- a/file_adoption.module
+++ b/file_adoption.module
@@ -13,6 +13,7 @@ function file_adoption_cron() {
   if ($config->get('enable_adoption')) {
     /** @var \Drupal\file_adoption\FileScanner $scanner */
     $scanner = \Drupal::service('file_adoption.file_scanner');
-    $scanner->scanAndProcess(TRUE);
+    $limit = (int) $config->get('items_per_run');
+    $scanner->scanAndProcess(TRUE, $limit);
   }
 }

--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -93,11 +93,13 @@ class FileScanner {
      *
      * @param bool $adopt
      *   Whether matching orphan files should be adopted.
+     * @param int $limit
+     *   Maximum number of orphans to adopt. 0 means no limit.
      *
      * @return array
      *   An associative array with the keys 'files', 'orphans' and 'adopted'.
      */
-    public function scanAndProcess(bool $adopt = TRUE) {
+    public function scanAndProcess(bool $adopt = TRUE, int $limit = 0) {
         $counts = ['files' => 0, 'orphans' => 0, 'adopted' => 0];
         $patterns = $this->getIgnorePatterns();
         // Only track whether the file is already managed.
@@ -112,6 +114,9 @@ class FileScanner {
         );
 
         foreach ($iterator as $file_info) {
+            if ($adopt && $limit > 0 && $counts['adopted'] >= $limit) {
+                break;
+            }
             if (!$file_info->isFile()) {
                 continue;
             }

--- a/tests/src/Kernel/FileScannerTest.php
+++ b/tests/src/Kernel/FileScannerTest.php
@@ -45,4 +45,31 @@ class FileScannerTest extends KernelTestBase {
     $this->assertEquals(['public://example.txt'], $results['to_manage']);
   }
 
+  /**
+   * Tests adoption limit handling.
+   */
+  public function testAdoptionLimit() {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save();
+
+    file_put_contents("$public/one.txt", '1');
+    file_put_contents("$public/two.txt", '2');
+
+    /** @var FileScanner $scanner */
+    $scanner = $this->container->get('file_adoption.file_scanner');
+
+    $result = $scanner->scanAndProcess(TRUE, 1);
+    $this->assertEquals(2, $result['files']);
+    $this->assertEquals(2, $result['orphans']);
+    $this->assertEquals(1, $result['adopted']);
+
+    $result = $scanner->scanAndProcess(TRUE, 1);
+    $this->assertEquals(2, $result['files']);
+    $this->assertEquals(1, $result['orphans']);
+    $this->assertEquals(1, $result['adopted']);
+
+    $result = $scanner->scanAndProcess(FALSE);
+    $this->assertEquals(0, $result['orphans']);
+  }
+
 }


### PR DESCRIPTION
## Summary
- allow limiting FileScanner::scanAndProcess() via optional parameter
- respect `items_per_run` when cron adopts orphans
- test scanner behaviour with adoption limit

## Testing
- `php -l src/FileScanner.php`
- `php -l file_adoption.module`
- `php -l tests/src/Kernel/FileScannerTest.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68558b8d85708331ba0fe2b55a568515