### PR TITLE
Remove unused variable

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -158,7 +158,6 @@ class FileAdoptionForm extends ConfigFormBase {
         }
 
         $absolute = $public_path . DIRECTORY_SEPARATOR . $entry;
-        $relative_file = $entry;
 
         if (is_dir($absolute)) {
           $relative_path = $entry . '/*';


### PR DESCRIPTION
## Summary
- tidy FileAdoptionForm::buildForm by removing an unused `$relative_file` variable

## Testing
- `phpunit tests` *(fails: Class "Drupal\KernelTests\KernelTestBase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_685591f7befc83319a04c8a604d7dcf6