### PR TITLE
Add kernel tests for cron and list limits

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -216,6 +216,9 @@ class FileScanner {
         );
 
         foreach ($iterator as $file_info) {
+            if ($limit > 0 && count($results['to_manage']) >= $limit) {
+                break;
+            }
             if (!$file_info->isFile()) {
                 continue;
             }

--- a/tests/src/Kernel/FileAdoptionCronTest.php
+++ b/tests/src/Kernel/FileAdoptionCronTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\Tests\file_adoption\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\file_adoption\FileScanner;
+
+/**
+ * Tests cron integration for the file_adoption module.
+ *
+ * @group file_adoption
+ */
+class FileAdoptionCronTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'file', 'file_adoption'];
+
+  /**
+   * Tests that cron respects the item limit configuration.
+   */
+  public function testCronLimit() {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save();
+
+    file_put_contents("$public/one.txt", '1');
+    file_put_contents("$public/two.txt", '2');
+
+    $this->config('file_adoption.settings')
+      ->set('enable_adoption', TRUE)
+      ->set('items_per_run', 1)
+      ->save();
+
+    // First cron run should adopt only one file.
+    file_adoption_cron();
+    /** @var FileScanner $scanner */
+    $scanner = $this->container->get('file_adoption.file_scanner');
+    $result = $scanner->scanAndProcess(FALSE);
+    $this->assertEquals(1, $result['orphans']);
+
+    // Second cron run should adopt the remaining file.
+    file_adoption_cron();
+    $result = $scanner->scanAndProcess(FALSE);
+    $this->assertEquals(0, $result['orphans']);
+  }
+
+}
+

--- a/tests/src/Kernel/FileScannerTest.php
+++ b/tests/src/Kernel/FileScannerTest.php
@@ -59,17 +59,37 @@ class FileScannerTest extends KernelTestBase {
     $scanner = $this->container->get('file_adoption.file_scanner');
 
     $result = $scanner->scanAndProcess(TRUE, 1);
-    $this->assertEquals(2, $result['files']);
-    $this->assertEquals(2, $result['orphans']);
+    $this->assertEquals(1, $result['files']);
+    $this->assertEquals(1, $result['orphans']);
     $this->assertEquals(1, $result['adopted']);
 
     $result = $scanner->scanAndProcess(TRUE, 1);
-    $this->assertEquals(2, $result['files']);
+    $this->assertEquals(1, $result['files']);
     $this->assertEquals(1, $result['orphans']);
     $this->assertEquals(1, $result['adopted']);
 
     $result = $scanner->scanAndProcess(FALSE);
     $this->assertEquals(0, $result['orphans']);
+  }
+
+  /**
+   * Ensures scanWithLists stops after the limit.
+   */
+  public function testScanWithListsLimit() {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save();
+
+    file_put_contents("$public/one.txt", '1');
+    file_put_contents("$public/two.txt", '2');
+    file_put_contents("$public/three.txt", '3');
+
+    /** @var FileScanner $scanner */
+    $scanner = $this->container->get('file_adoption.file_scanner');
+
+    $results = $scanner->scanWithLists(2);
+    $this->assertEquals(2, $results['files']);
+    $this->assertEquals(2, $results['orphans']);
+    $this->assertCount(2, $results['to_manage']);
   }
 
 }


### PR DESCRIPTION
## Summary
- enforce limit early in `scanWithLists()`
- adjust adoption limit test and add scan limit test
- add cron integration test
- ensure form list respects item limit

## Testing
- `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855956f1c188331b759aad2b102fe59