### PR TITLE
Document items-per-run config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The configuration form offers the following options:
   `public://`) that should be skipped when scanning.
 - **Enable Adoption** – When checked, cron will automatically adopt orphaned
   files using the configured settings.
+- **Items per cron run** – Numeric limit that controls how many files are
+  processed or displayed per execution. Defaults to 10.
 
 Changes are stored in `file_adoption.settings`.
 


### PR DESCRIPTION
## Summary
- document new numeric config option in the README

## Testing
- `composer install --dev` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685598f070648331843a410802ce89ca