### PR TITLE
Set default cron limit to 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The configuration form offers the following options:
   `public://`) that should be skipped when scanning.
 - **Enable Adoption** – When checked, cron will automatically adopt orphaned
   files using the configured settings.
+- **Items per cron run** – Maximum number of files processed and displayed per
+  scan or cron run. Defaults to 20.
 
 Changes are stored in `file_adoption.settings`.
 

--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -8,4 +8,4 @@ ignore_patterns: |
   php/*
   styles/*
 enable_adoption: false
-items_per_run: 10
+items_per_run: 20

--- a/file_adoption.install
+++ b/file_adoption.install
@@ -6,7 +6,7 @@
 function file_adoption_update_10001() {
   $config = \Drupal::configFactory()->getEditable('file_adoption.settings');
   if ($config->get('items_per_run') === NULL) {
-    $config->set('items_per_run', 10)->save();
+    $config->set('items_per_run', 20)->save();
   }
   return t('Added items_per_run setting.');
 }

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -85,10 +85,14 @@ class FileAdoptionForm extends ConfigFormBase {
       '#description' => $this->t('If checked, orphaned files will be adopted automatically during cron runs.'),
     ];
 
+    $items_per_run = $config->get('items_per_run');
+    if (empty($items_per_run)) {
+      $items_per_run = 20;
+    }
     $form['items_per_run'] = [
       '#type' => 'number',
       '#title' => $this->t('Items per cron run'),
-      '#default_value' => $config->get('items_per_run'),
+      '#default_value' => $items_per_run,
       '#min' => 1,
     ];
 
@@ -285,10 +289,14 @@ class FileAdoptionForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    $items_per_run = (int) $form_state->getValue('items_per_run');
+    if ($items_per_run <= 0) {
+      $items_per_run = 20;
+    }
     $this->config('file_adoption.settings')
       ->set('ignore_patterns', $form_state->getValue('ignore_patterns'))
       ->set('enable_adoption', $form_state->getValue('enable_adoption'))
-      ->set('items_per_run', (int) $form_state->getValue('items_per_run'))
+      ->set('items_per_run', $items_per_run)
       ->save();
 
     $trigger = $form_state->getTriggeringElement()['#name'] ?? '';


### PR DESCRIPTION
## Summary
- set default `items_per_run` to 20 in default config and update hook
- guard the form so empty values fall back to 20
- update README with new setting

## Testing
- `composer --version` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68557fa930e0833198437138fa62e2a8