### PR TITLE
Implement ignore-aware file counting

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -200,9 +200,7 @@ class FileAdoptionForm extends ConfigFormBase {
             $preview[] = '<li><span style="color:gray">' . Html::escape($label) . ' (matches pattern ' . Html::escape($matched) . ')</span></li>';
           }
           else {
-            // Count files contained within this directory using a fast shell command.
-            $command = 'find ' . escapeshellarg($absolute) . ' -type f | wc -l';
-            $count_dir = (int) shell_exec($command);
+            $count_dir = $this->fileScanner->countFiles($entry);
             if ($count_dir > 0) {
               $label .= ' (' . $count_dir . ')';
             }

--- a/tests/src/Kernel/FileScannerTest.php
+++ b/tests/src/Kernel/FileScannerTest.php
@@ -92,4 +92,26 @@ class FileScannerTest extends KernelTestBase {
     $this->assertCount(2, $results['to_manage']);
   }
 
+  /**
+   * Tests countFiles respects nested ignore patterns.
+   */
+  public function testCountFilesWithNestedIgnore() {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save();
+
+    mkdir("$public/thousand/testfiles", 0777, TRUE);
+    file_put_contents("$public/thousand/testfiles/ignore.txt", 'x');
+    file_put_contents("$public/thousand/keep.txt", 'y');
+
+    $this->config('file_adoption.settings')
+      ->set('ignore_patterns', "thousand/testfiles/*")
+      ->save();
+
+    /** @var FileScanner $scanner */
+    $scanner = $this->container->get('file_adoption.file_scanner');
+
+    $count = $scanner->countFiles('thousand');
+    $this->assertEquals(1, $count);
+  }
+
 }


### PR DESCRIPTION
## Summary
- add FileScanner::countFiles() to get counts with ignore patterns
- use the new method in FileAdoptionForm instead of shell calls
- test nested ignore patterns for scanner and preview listing

## Testing
- `php -l src/FileScanner.php`
- `php -l src/Form/FileAdoptionForm.php`
- `php -l tests/src/Kernel/FileScannerTest.php`
- `php -l tests/src/Kernel/FileAdoptionFormTest.php`
- `phpunit tests/src/Kernel/FileScannerTest.php` *(fails: Class "Drupal\KernelTests\KernelTestBase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855aa656ed883319b439406b512f30c