### PR TITLE
Use FileScanner for preview totals

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -100,16 +100,8 @@ class FileAdoptionForm extends ConfigFormBase {
 
     $public_path = $this->fileSystem->realpath('public://');
     $file_count = 0;
-    if ($public_path && function_exists('shell_exec')) {
-      $escaped = escapeshellarg($public_path);
-      $output = shell_exec("find $escaped -type f | wc -l");
-      if (is_string($output)) {
-        $file_count = (int) trim($output);
-      }
-    }
-    if ($file_count === 0 && $public_path) {
-      $scan_summary = $this->fileScanner->scanAndProcess(FALSE);
-      $file_count = $scan_summary['files'];
+    if ($public_path) {
+      $file_count = $this->fileScanner->countFiles();
     }
 
     $form['preview'] = [

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -108,4 +108,31 @@ class FileAdoptionFormTest extends KernelTestBase {
     $this->assertStringNotContainsString('(2)', $markup);
   }
 
+  /**
+   * Tests main preview count uses ignore patterns.
+   */
+  public function testPreviewMainCountUsesIgnorePatterns() {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save();
+
+    mkdir("$public/ignored", 0777, TRUE);
+    file_put_contents("$public/ignored/file.txt", 'x');
+    file_put_contents("$public/keep.txt", 'y');
+
+    $this->config('file_adoption.settings')->set('ignore_patterns', 'ignored/*')->save();
+
+    $form_state = new FormState();
+
+    $form_object = new FileAdoptionForm(
+      $this->container->get('file_adoption.file_scanner'),
+      $this->container->get('file_system')
+    );
+
+    $form = $form_object->buildForm([], $form_state);
+
+    $title = (string) $form['preview']['#title'];
+    $this->assertStringContainsString('(1)', $title);
+    $this->assertStringNotContainsString('(2)', $title);
+  }
+
 }


### PR DESCRIPTION
## Summary
- integrate `FileScanner::countFiles()` into form preview
- test that preview file count respects ignore patterns

## Testing
- `php -l src/Form/FileAdoptionForm.php`
- `php -l tests/src/Kernel/FileAdoptionFormTest.php`
- `phpunit --bootstrap vendor/autoload.php tests/src/Kernel/FileAdoptionFormTest.php` *(fails: Class "Drupal\KernelTests\KernelTestBase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855aed1ec088331acd1d778013929ac