### PR TITLE
Update README and composer.json for VCS install

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ for files that are not tracked by Drupal's `file_managed` table. Identified
    ```bash
    composer require dbrabon/file_adoption
    ```
-   or by copying the module into `modules/custom`.
+   **Note:** The module has not yet been published on Packagist. Until it is
+   available there, add it as a VCS repository in your project's `composer.json`.
+   Alternatively, copy the module into `modules/custom`.
 2. Enable the module from the **Extend** page or with Drush:
    ```bash
    drush en file_adoption

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,12 @@
       "role": "Maintainer"
     }
   ],
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/dbrabon/file_adoption"
+    }
+  ],
   "require": {
     "php": ">=8.2"
   },


### PR DESCRIPTION
## Summary
- document requiring the package from a VCS repository until published on Packagist
- show repository entry in `composer.json`

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593a5bfce083318b936506b73164a2