### PR TITLE
Remove developer info from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,10 @@ for files that are not tracked by Drupal's `file_managed` table. Identified
 
 ## Installation
 
-1. Place the module in your Drupal installation, typically using Composer:
+1. Place the module in your Drupal installation using Composer:
    ```bash
    composer require dbrabon/file_adoption
    ```
-   **Note:** The module has not yet been published on Packagist. Until it is
-   available there, add it as a VCS repository in your project's `composer.json`.
    Alternatively, copy the module into `modules/custom`.
 2. Enable the module from the **Extend** page or with Drush:
    ```bash
@@ -46,31 +44,6 @@ To run a scan on demand:
 2. Click **Scan Now** to see a list of files that would be adopted.
 3. Review the results and click **Adopt** to create the file entities.
 
-## Packagist Webhook
-
-To keep the package on [Packagist](https://packagist.org) in sync with the
-repository, enable the **Packagist** service hook on GitHub:
-
-1. Navigate to the repository **Settings** and open **Webhooks**.
-2. Click **Add service** and choose **Packagist** from the list.
-3. Provide your package name and API token, then save.
-
-Packagist will now fetch updates whenever you push changes.
-
-# file_adoption
-
-## Running Tests
-
-1. Install the module's dependencies, including those in `require-dev`:
-   ```bash
-   composer install
-   ```
-2. Execute PHPUnit from the module directory:
-   ```bash
-   vendor/bin/phpunit
-   ```
-
-The tests are located under the `tests/` directory and include kernel tests for the `FileScanner` service and the configuration form.
 
 ## License
 


### PR DESCRIPTION
## Summary
- remove Packagist webhook instructions
- drop testing steps and dev-focused content
- streamline installation instructions for users

## Testing
- `composer install` *(fails: composer not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685949f1bd5483319e7b4c3e8ac6426e