### PR TITLE
Switch to ^8.2 PHP requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "php": ">=8.2"
+    "php": "^8.2"
   },
   "require-dev": {
     "drupal/core": "^10 || ^11",

--- a/composer.lock
+++ b/composer.lock
@@ -6020,7 +6020,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.2"
+        "php": "^8.2"
     },
     "platform-dev": [],
     "plugin-api-version": "2.6.0"


### PR DESCRIPTION
## Summary
- change PHP requirement to `^8.2` in `composer.json`
- update the lock file `composer.lock`

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a2e93fab88331acd53b36c37a5960