### PR TITLE
Add AJAX preview for file adoption

### DIFF
--- a/file_adoption.libraries.yml
+++ b/file_adoption.libraries.yml
@@ -1,0 +1,6 @@
+preview:
+  js:
+    js/preview.js: {}
+  dependencies:
+    - core/drupal
+    - core/jquery

--- a/file_adoption.routing.yml
+++ b/file_adoption.routing.yml
@@ -5,3 +5,11 @@ file_adoption.config_form:
     _title: 'File Adoption'
   requirements:
     _permission: 'administer site configuration'
+file_adoption.preview_ajax:
+  path: '/admin/reports/file-adoption/preview'
+  defaults:
+    _controller: '\Drupal\file_adoption\Controller\PreviewController::preview'
+  requirements:
+    _permission: 'administer site configuration'
+  options:
+    _format: 'json'

--- a/file_adoption.services.yml
+++ b/file_adoption.services.yml
@@ -10,3 +10,10 @@ services:
       - '@database'
       - '@config.factory'
       - '@logger.channel.file_adoption'
+  file_adoption.preview_controller:
+    class: 'Drupal\file_adoption\Controller\PreviewController'
+    arguments:
+      - '@file_adoption.file_scanner'
+      - '@file_system'
+    tags:
+      - controller.service_arguments

--- a/js/preview.js
+++ b/js/preview.js
@@ -1,0 +1,36 @@
+(function (Drupal, drupalSettings) {
+  Drupal.behaviors.fileAdoptionPreview = {
+    attach: function (context, settings) {
+      if (context !== document) {
+        return;
+      }
+      const url = drupalSettings.file_adoption.preview_url;
+      const wrapper = document.getElementById('file-adoption-preview');
+      const details = document.getElementById('file-adoption-preview-wrapper');
+      if (!url || !wrapper) {
+        return;
+      }
+
+      function loadPreview() {
+        fetch(url)
+          .then((response) => response.json())
+          .then((data) => {
+            if (data.markup) {
+              wrapper.innerHTML = data.markup;
+              if (details && typeof data.count !== 'undefined') {
+                const summary = details.querySelector('summary');
+                if (summary) {
+                  summary.textContent = drupalSettings.file_adoption.preview_title + ' (' + data.count + ')';
+                }
+              }
+              clearInterval(intervalId);
+            }
+          })
+          .catch(() => {});
+      }
+
+      const intervalId = setInterval(loadPreview, 3000);
+      loadPreview();
+    }
+  };
+})(Drupal, drupalSettings);

--- a/src/Controller/PreviewController.php
+++ b/src/Controller/PreviewController.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Drupal\file_adoption\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Drupal\file_adoption\FileScanner;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Render\Markup;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Returns preview markup for the file adoption form.
+ */
+class PreviewController extends ControllerBase {
+
+  /**
+   * The file scanner service.
+   *
+   * @var \Drupal\file_adoption\FileScanner
+   */
+  protected $fileScanner;
+
+  /**
+   * The file system service.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  /**
+   * Constructs the controller.
+   */
+  public function __construct(FileScanner $fileScanner, FileSystemInterface $fileSystem) {
+    $this->fileScanner = $fileScanner;
+    $this->fileSystem = $fileSystem;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('file_adoption.file_scanner'),
+      $container->get('file_system')
+    );
+  }
+
+  /**
+   * Provides preview markup as JSON.
+   */
+  public function preview(): JsonResponse {
+    $public_path = $this->fileSystem->realpath('public://');
+    $file_count = 0;
+    if ($public_path) {
+      $file_count = $this->fileScanner->countFiles();
+    }
+
+    $preview = [];
+    if ($public_path && is_dir($public_path)) {
+      $entries = scandir($public_path);
+      $patterns = $this->fileScanner->getIgnorePatterns();
+      $matched_patterns = [];
+
+      $find_first_file = function ($dir) {
+        if (!is_dir($dir)) {
+          return NULL;
+        }
+        $it = new \FilesystemIterator($dir, \FilesystemIterator::SKIP_DOTS);
+        foreach ($it as $file) {
+          if ($file->isFile()) {
+            $name = $file->getFilename();
+            if (!str_starts_with($name, '.')) {
+              return $name;
+            }
+          }
+        }
+        return NULL;
+      };
+
+      $root_first = $find_first_file($public_path);
+      $root_label = 'public://';
+      if ($root_first) {
+        $root_label .= ' (e.g., ' . $root_first . ')';
+      }
+      $root_count = 0;
+      foreach ($entries as $entry_check) {
+        if ($entry_check === '.' || $entry_check === '..' || str_starts_with($entry_check, '.')) {
+          continue;
+        }
+        $absolute = $public_path . DIRECTORY_SEPARATOR . $entry_check;
+        if (is_file($absolute)) {
+          $ignored = FALSE;
+          foreach ($patterns as $pattern) {
+            if ($pattern !== '' && fnmatch($pattern, $entry_check)) {
+              $ignored = TRUE;
+              $matched_patterns[$pattern] = TRUE;
+              break;
+            }
+          }
+          if (!$ignored) {
+            $root_count++;
+          }
+        }
+      }
+      if ($root_count > 0) {
+        $root_label .= ' (' . $root_count . ')';
+      }
+
+      $preview[] = '<li>' . Html::escape($root_label) . '</li>';
+
+      foreach ($entries as $entry) {
+        if ($entry === '.' || $entry === '..' || str_starts_with($entry, '.')) {
+          continue;
+        }
+
+        $absolute = $public_path . DIRECTORY_SEPARATOR . $entry;
+
+        if (is_dir($absolute)) {
+          $relative_path = $entry . '/*';
+          $first_file = $find_first_file($absolute);
+          $label = $entry . '/';
+          if ($first_file) {
+            $label .= ' (e.g., ' . $first_file . ')';
+          }
+        }
+        else {
+          $relative_path = $entry;
+          $label = $entry;
+        }
+
+        $matched = '';
+        foreach ($patterns as $pattern) {
+          if (fnmatch($pattern, $relative_path) || fnmatch($pattern, $entry)) {
+            $matched = $pattern;
+            $matched_patterns[$pattern] = TRUE;
+            break;
+          }
+        }
+
+        if (is_dir($absolute)) {
+          if ($matched) {
+            $preview[] = '<li><span style="color:gray">' . Html::escape($label) . ' (matches pattern ' . Html::escape($matched) . ')</span></li>';
+          }
+          else {
+            $count_dir = $this->fileScanner->countFiles($entry);
+            if ($count_dir > 0) {
+              $label .= ' (' . $count_dir . ')';
+            }
+            $preview[] = '<li>' . Html::escape($label) . '</li>';
+          }
+        }
+        elseif ($matched) {
+          $preview[] = '<li><span style="color:gray">' . Html::escape($label) . ' (matches pattern ' . Html::escape($matched) . ')</span></li>';
+        }
+      }
+
+      foreach ($patterns as $pattern) {
+        if (!isset($matched_patterns[$pattern])) {
+          $preview[] = '<li><span style="color:gray">' . Html::escape($pattern) . ' (pattern not found)</span></li>';
+        }
+      }
+    }
+
+    $list_html = '';
+    if (!empty($preview)) {
+      $list_html = '<ul>' . implode('', $preview) . '</ul>';
+      $list_html = '<div>' . $list_html . '</div>';
+    }
+
+    return new JsonResponse([
+      'markup' => $list_html,
+      'count' => $file_count,
+    ]);
+  }
+
+}

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -5,6 +5,7 @@ namespace Drupal\file_adoption\Form;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\file_adoption\FileScanner;
+use Drupal\Core\Url;
 use Drupal\Core\File\FileSystemInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Render\Markup;
@@ -97,146 +98,19 @@ class FileAdoptionForm extends ConfigFormBase {
     ];
 
 
-
-    $public_path = $this->fileSystem->realpath('public://');
-    $file_count = 0;
-    if ($public_path) {
-      $file_count = $this->fileScanner->countFiles();
-    }
-
     $form['preview'] = [
       '#type' => 'details',
-      '#title' => $this->t('Public Directory Contents Preview (@count)', [
-        '@count' => $file_count,
-      ]),
+      '#title' => $this->t('Public Directory Contents Preview'),
       '#open' => TRUE,
+      '#attributes' => ['id' => 'file-adoption-preview-wrapper'],
     ];
-    $preview = [];
+    $form['preview']['markup'] = [
+      '#markup' => Markup::create('<div id="file-adoption-preview">' . $this->t('Scanning files…') . '</div>'),
+    ];
+    $form['#attached']['library'][] = 'file_adoption/preview';
+    $form['#attached']['drupalSettings']['file_adoption']['preview_url'] = Url::fromRoute('file_adoption.preview_ajax')->toString();
+    $form['#attached']['drupalSettings']['file_adoption']['preview_title'] = $this->t('Public Directory Contents Preview');
 
-    if ($public_path && is_dir($public_path)) {
-      $entries = scandir($public_path);
-      $patterns = $this->fileScanner->getIgnorePatterns();
-      $matched_patterns = [];
-
-        $find_first_file = function ($dir) {
-          if (!is_dir($dir)) {
-            return NULL;
-          }
-          $it = new \FilesystemIterator($dir, \FilesystemIterator::SKIP_DOTS);
-          foreach ($it as $file) {
-            if ($file->isFile()) {
-              $name = $file->getFilename();
-              if (!str_starts_with($name, '.')) {
-                return $name;
-              }
-            }
-          }
-          return NULL;
-        };
-
-      // Show the root public:// folder with a sample file if available.
-      $root_first = $find_first_file($public_path);
-      $root_label = 'public://';
-      if ($root_first) {
-        $root_label .= ' (e.g., ' . $root_first . ')';
-      }
-
-      // Count only files directly within the root public directory that are not
-      // ignored by configured patterns.
-      $root_count = 0;
-      foreach ($entries as $entry_check) {
-        if ($entry_check === '.' || $entry_check === '..' || str_starts_with($entry_check, '.')) {
-          continue;
-        }
-        $absolute = $public_path . DIRECTORY_SEPARATOR . $entry_check;
-        if (is_file($absolute)) {
-          $ignored = FALSE;
-          foreach ($patterns as $pattern) {
-            if ($pattern !== '' && fnmatch($pattern, $entry_check)) {
-              $ignored = TRUE;
-              $matched_patterns[$pattern] = TRUE;
-              break;
-            }
-          }
-          if (!$ignored) {
-            $root_count++;
-          }
-        }
-      }
-      if ($root_count > 0) {
-        $root_label .= ' (' . $root_count . ')';
-      }
-
-      $preview[] = '<li>' . Html::escape($root_label) . '</li>';
-
-      foreach ($entries as $entry) {
-        if ($entry === '.' || $entry === '..' || str_starts_with($entry, '.')) {
-          continue;
-        }
-
-        $absolute = $public_path . DIRECTORY_SEPARATOR . $entry;
-
-        if (is_dir($absolute)) {
-          $relative_path = $entry . '/*';
-          $first_file = $find_first_file($absolute);
-          $label = $entry . '/';
-          if ($first_file) {
-            $label .= ' (e.g., ' . $first_file . ')';
-          }
-        }
-        else {
-          // Only list files that match an ignore pattern.
-          $relative_path = $entry;
-          $label = $entry;
-        }
-
-        $matched = '';
-        foreach ($patterns as $pattern) {
-          if (fnmatch($pattern, $relative_path) || fnmatch($pattern, $entry)) {
-            $matched = $pattern;
-            $matched_patterns[$pattern] = TRUE;
-            break;
-          }
-        }
-
-        if (is_dir($absolute)) {
-          if ($matched) {
-            $preview[] = '<li><span style="color:gray">' . Html::escape($label) . ' (matches pattern ' . Html::escape($matched) . ')</span></li>';
-          }
-          else {
-            $count_dir = $this->fileScanner->countFiles($entry);
-            if ($count_dir > 0) {
-              $label .= ' (' . $count_dir . ')';
-            }
-            $preview[] = '<li>' . Html::escape($label) . '</li>';
-          }
-        }
-        elseif ($matched) {
-          $preview[] = '<li><span style="color:gray">' . Html::escape($label) . ' (matches pattern ' . Html::escape($matched) . ')</span></li>';
-        }
-      }
-
-      // Display patterns that did not match any current file or directory.
-      foreach ($patterns as $pattern) {
-        if (!isset($matched_patterns[$pattern])) {
-          $preview[] = '<li><span style="color:gray">' . Html::escape($pattern) . ' (pattern not found)</span></li>';
-        }
-      }
-    }
-
-    if (!empty($preview)) {
-      $list_html = '<ul>' . implode('', $preview) . '</ul>';
-      if (count($preview) > 20) {
-        $form['preview']['list'] = [
-          '#markup' => Markup::create('<div>' . $list_html . '</div>'),
-        ];
-      }
-      else {
-        $form['preview']['markup'] = [
-          '#markup' => Markup::create('<div>' . $list_html . '</div>'),
-        ];
-      }
-    }
 
     $form['actions'] = [
       '#type' => 'actions',

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\file_adoption\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\file_adoption\Form\FileAdoptionForm;
+use Drupal\file_adoption\Controller\PreviewController;
 use Drupal\Core\Form\FormState;
 
 /**
@@ -92,16 +93,12 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $this->config('file_adoption.settings')->set('ignore_patterns', 'thousand/testfiles/*')->save();
 
-    $form_state = new FormState();
-
-    $form_object = new FileAdoptionForm(
+    $controller = new PreviewController(
       $this->container->get('file_adoption.file_scanner'),
       $this->container->get('file_system')
     );
-
-    $form = $form_object->buildForm([], $form_state);
-
-    $markup = $form['preview']['markup']['#markup'] ?? $form['preview']['list']['#markup'];
+    $data = json_decode($controller->preview()->getContent(), TRUE);
+    $markup = $data['markup'];
 
     $this->assertStringContainsString('thousand/', $markup);
     $this->assertStringContainsString('(1)', $markup);
@@ -121,18 +118,12 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $this->config('file_adoption.settings')->set('ignore_patterns', 'ignored/*')->save();
 
-    $form_state = new FormState();
-
-    $form_object = new FileAdoptionForm(
+    $controller = new PreviewController(
       $this->container->get('file_adoption.file_scanner'),
       $this->container->get('file_system')
     );
-
-    $form = $form_object->buildForm([], $form_state);
-
-    $title = (string) $form['preview']['#title'];
-    $this->assertStringContainsString('(1)', $title);
-    $this->assertStringNotContainsString('(2)', $title);
+    $data = json_decode($controller->preview()->getContent(), TRUE);
+    $this->assertEquals(1, $data['count']);
   }
 
   /**
@@ -150,18 +141,12 @@ class FileAdoptionFormTest extends KernelTestBase {
       ->set('ignore_patterns', "skip.txt\n*.log")
       ->save();
 
-    $form_state = new FormState();
-
-    $form_object = new FileAdoptionForm(
+    $controller = new PreviewController(
       $this->container->get('file_adoption.file_scanner'),
       $this->container->get('file_system')
     );
-
-    $form = $form_object->buildForm([], $form_state);
-
-    $title = (string) $form['preview']['#title'];
-    $this->assertStringContainsString('(1)', $title);
-    $this->assertStringNotContainsString('(2)', $title);
+    $data = json_decode($controller->preview()->getContent(), TRUE);
+    $this->assertEquals(1, $data['count']);
   }
 
 }


### PR DESCRIPTION
## Summary
- return preview markup via new `file_adoption.preview_ajax` route
- poll the new route from the configuration form with JavaScript
- move preview generation to `PreviewController`
- update tests for the new controller

## Testing
- `phpunit -c phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad4a32f388331a93e1e17c474d715