### PR TITLE
Add 500 item cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The configuration form offers the following options:
 - **Enable Adoption** – When checked, cron will automatically adopt orphaned
   files using the configured settings.
 - **Items per cron run** – Maximum number of files processed and displayed per
-  scan or cron run. Defaults to 20.
+  scan or cron run. Defaults to 20 and capped at 500.
 
 Changes are stored in `file_adoption.settings`.
 

--- a/file_adoption.module
+++ b/file_adoption.module
@@ -14,6 +14,9 @@ function file_adoption_cron() {
     /** @var \Drupal\file_adoption\FileScanner $scanner */
     $scanner = \Drupal::service('file_adoption.file_scanner');
     $limit = (int) $config->get('items_per_run');
+    if ($limit > 500) {
+      $limit = 500;
+    }
     $scanner->scanAndProcess(TRUE, $limit);
   }
 }

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -90,11 +90,15 @@ class FileAdoptionForm extends ConfigFormBase {
     if (empty($items_per_run)) {
       $items_per_run = 20;
     }
+    elseif ($items_per_run > 500) {
+      $items_per_run = 500;
+    }
     $form['items_per_run'] = [
       '#type' => 'number',
       '#title' => $this->t('Items per cron run'),
       '#default_value' => $items_per_run,
       '#min' => 1,
+      '#max' => 500,
     ];
 
 
@@ -168,6 +172,9 @@ class FileAdoptionForm extends ConfigFormBase {
     $items_per_run = (int) $form_state->getValue('items_per_run');
     if ($items_per_run <= 0) {
       $items_per_run = 20;
+    }
+    elseif ($items_per_run > 500) {
+      $items_per_run = 500;
     }
     $this->config('file_adoption.settings')
       ->set('ignore_patterns', $form_state->getValue('ignore_patterns'))

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -149,4 +149,21 @@ class FileAdoptionFormTest extends KernelTestBase {
     $this->assertEquals(1, $data['count']);
   }
 
+  /**
+   * Ensures the items per run value is capped at 500.
+   */
+  public function testItemsPerRunCap() {
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setValue('items_per_run', 999);
+
+    $form_object = new FileAdoptionForm(
+      $this->container->get('file_adoption.file_scanner'),
+      $this->container->get('file_system')
+    );
+    $form_object->submitForm($form, $form_state);
+
+    $this->assertEquals(500, $this->config('file_adoption.settings')->get('items_per_run'));
+  }
+
 }


### PR DESCRIPTION
## Summary
- set maximum of 500 items per cron run
- respect the cap in cron and form logic
- document cron run cap in README
- test that the cap is applied

## Testing
- `vendor/bin/phpunit --bootstrap vendor/autoload.php tests/src/Kernel/FileAdoptionFormTest.php` *(fails: Class "Drupal\KernelTests\KernelTestBase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae29834f483319e15b9f2ae3cd4dd