### PR TITLE
docs: add development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ To run a scan on demand:
 2. Click **Scan Now** to see a list of files that would be adopted.
 3. Review the results and click **Adopt** to create the file entities.
 
+## Development
+
+This module requires **PHP 8.2** or later. Install the development dependencies
+with Composer:
+
+```bash
+composer install
+```
+
+Once the dependencies are installed, run the test suite with:
+
+```bash
+phpunit -c phpunit.xml.dist
+```
+
 
 ## License
 


### PR DESCRIPTION
## Summary
- document composer install for dev deps and PHP 8.2 requirement
- add command to run PHPUnit with phpunit.xml.dist

## Testing
- `composer install` *(fails: command not found)*
- `phpunit -c phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685afe25aa108331ba7c1332d3abc392