### PR TITLE
Add preview scanning progress

### DIFF
--- a/file_adoption.routing.yml
+++ b/file_adoption.routing.yml
@@ -13,3 +13,11 @@ file_adoption.preview_ajax:
     _permission: 'administer site configuration'
   options:
     _format: 'json'
+file_adoption.preview_progress:
+  path: '/admin/reports/file-adoption/preview/progress'
+  defaults:
+    _controller: '\Drupal\file_adoption\Controller\PreviewController::progress'
+  requirements:
+    _permission: 'administer site configuration'
+  options:
+    _format: 'json'

--- a/file_adoption.services.yml
+++ b/file_adoption.services.yml
@@ -15,5 +15,6 @@ services:
     arguments:
       - '@file_adoption.file_scanner'
       - '@file_system'
+      - '@state'
     tags:
       - controller.service_arguments

--- a/js/preview.js
+++ b/js/preview.js
@@ -5,6 +5,7 @@
         return;
       }
       const url = drupalSettings.file_adoption.preview_url;
+      const progressUrl = drupalSettings.file_adoption.progress_url;
       const wrapper = document.getElementById('file-adoption-preview');
       const details = document.getElementById('file-adoption-preview-wrapper');
       if (!url || !wrapper) {
@@ -24,13 +25,29 @@
                 }
               }
               clearInterval(intervalId);
+              clearInterval(progressId);
+            }
+          })
+          .catch(() => {});
+      }
+
+      function checkProgress() {
+        if (!progressUrl) {
+          return;
+        }
+        fetch(progressUrl)
+          .then((response) => response.json())
+          .then((data) => {
+            if (data.total && data.current <= data.total) {
+              wrapper.textContent = 'Scanning files (' + data.current + ' of ' + data.total + ')';
             }
           })
           .catch(() => {});
       }
 
       const intervalId = setInterval(loadPreview, 3000);
+      const progressId = setInterval(checkProgress, 1000);
       loadPreview();
-    }
+   }
   };
 })(Drupal, drupalSettings);

--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -143,6 +143,7 @@ class FileScanner {
             new \RecursiveDirectoryIterator($public_realpath, \FilesystemIterator::SKIP_DOTS)
         );
 
+        $processed = 0;
         foreach ($iterator as $file_info) {
             if ($adopt && $limit > 0 && $counts['adopted'] >= $limit) {
                 break;
@@ -326,7 +327,7 @@ class FileScanner {
      * @return array
      *   Associative array of directory paths and counts.
      */
-    public function countFilesByDirectory(string $relative_path = ''): array {
+    public function countFilesByDirectory(string $relative_path = '', callable $progress_callback = NULL): array {
         $patterns = $this->getIgnorePatterns();
         $public_realpath = $this->fileSystem->realpath('public://');
 
@@ -388,6 +389,11 @@ class FileScanner {
                 if ($dir === '.') {
                     $dir = '';
                 }
+            }
+
+            $processed++;
+            if ($progress_callback) {
+                $progress_callback($processed);
             }
         }
 

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -113,6 +113,7 @@ class FileAdoptionForm extends ConfigFormBase {
     ];
     $form['#attached']['library'][] = 'file_adoption/preview';
     $form['#attached']['drupalSettings']['file_adoption']['preview_url'] = Url::fromRoute('file_adoption.preview_ajax')->toString();
+    $form['#attached']['drupalSettings']['file_adoption']['progress_url'] = Url::fromRoute('file_adoption.preview_progress')->toString();
     $form['#attached']['drupalSettings']['file_adoption']['preview_title'] = $this->t('Public Directory Contents Preview');
 
 


### PR DESCRIPTION
## Summary
- add a progress endpoint to report scanning status
- update FileScanner to support progress callbacks
- store progress state in PreviewController
- poll progress in preview.js while files are scanned

## Testing
- `php -l src/FileScanner.php`
- `php -l src/Controller/PreviewController.php`
- `php -l src/Form/FileAdoptionForm.php`
- `composer install --ignore-platform-req=ext-intl`
- `vendor/bin/phpunit tests/src` *(fails: Class "Drupal\KernelTests\KernelTestBase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b098f45048331920704ab2a448797