### PR TITLE
Add PHPUnit configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,16 @@ with Composer:
 composer install
 ```
 
-Once the dependencies are installed, run the test suite with:
+Once the dependencies are installed, run the test suite using the provided
+PHPUnit configuration:
 
 ```bash
-phpunit -c phpunit.xml.dist
+vendor/bin/phpunit --configuration phpunit.xml.dist
 ```
+
+If the module is installed inside an existing Drupal site, you may instead run
+`vendor/bin/phpunit` from the Drupal root using that installation's
+`phpunit.xml` file.
 
 
 ## License

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/drupal/core/tests/bootstrap.php"
+         colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+         failOnWarning="true"
+         printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter"
+         cacheResult="false">
+  <php>
+    <ini name="error_reporting" value="32767"/>
+    <ini name="memory_limit" value="-1"/>
+    <env name="SIMPLETEST_BASE_URL" value="http://localhost"/>
+    <env name="SIMPLETEST_DB" value="sqlite://localhost/sites/default/files/.ht.sqlite"/>
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/tmp"/>
+  </php>
+  <testsuites>
+    <testsuite name="kernel">
+      <directory>./tests/src/Kernel</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>


### PR DESCRIPTION
## Summary
- add a phpunit.xml.dist configured for KernelTestBase
- document how to run tests

## Testing
- `composer install --no-interaction` *(fails: composer not found)*
- `phpunit --version` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb37dfb9c833189662574b86dbc18