### PR TITLE
Clarify scan summary limit

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -187,7 +187,7 @@ class FileAdoptionForm extends ConfigFormBase {
       $limit = (int) $this->config('file_adoption.settings')->get('items_per_run');
       $result = $this->fileScanner->scanWithLists($limit);
       $form_state->set('scan_results', $result);
-      $this->messenger()->addStatus($this->t('Scan complete: @count file(s) found.', ['@count' => $result['files']]));
+      $this->messenger()->addStatus($this->t('Scan complete: @count file(s) found. Counts are limited by "Items per cron run".', ['@count' => $result['files']]));
       $form_state->setRebuild(TRUE);
     }
     elseif ($trigger === 'adopt') {


### PR DESCRIPTION
## Summary
- clarify scan summary message with limit explanation

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: Error in bootstrap script)*

------
https://chatgpt.com/codex/tasks/task_e_685bb6b9a0a88331bf695383e26fdc06