### PR TITLE
Add drush command for duplicate cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ To run a scan on demand:
 2. Click **Scan Now** to see a list of files that would be adopted.
 3. Review the results and click **Adopt** to create the file entities.
 
+## Removing Duplicate File Entries
+
+Duplicate `file_managed` rows occasionally accumulate when the same file is
+imported multiple times. Clean these up with the included Drush command:
+
+```bash
+drush file_adoption:dedupe
+```
+
+The command keeps the newest database record for each URI and deletes any older
+duplicates.
+
 ## Development
 
 This module requires **PHP 8.2** or later. Install the development dependencies

--- a/src/Commands/FileAdoptionCommands.php
+++ b/src/Commands/FileAdoptionCommands.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\file_adoption\Commands;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drush\Commands\DrushCommands;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Drush commands for the File Adoption module.
+ */
+class FileAdoptionCommands extends DrushCommands {
+
+  /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $database;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs the commands object.
+   */
+  public function __construct(Connection $database, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct();
+    $this->database = $database;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new static(
+      $container->get('database'),
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * Removes duplicate file_managed records by URI, keeping the newest entry.
+   *
+   * @command file_adoption:dedupe
+   * @aliases fad-dedupe
+   *
+   * @usage drush file_adoption:dedupe
+   *   Remove duplicate file_managed rows.
+   */
+  public function dedupe(): void {
+    $duplicate_uris = $this->database->select('file_managed', 'fm')
+      ->fields('fm', ['uri'])
+      ->groupBy('uri')
+      ->having('COUNT(fid) > 1')
+      ->execute()
+      ->fetchCol();
+
+    if (!$duplicate_uris) {
+      $this->logger()->notice('No duplicate file_managed entries found.');
+      return;
+    }
+
+    $storage = $this->entityTypeManager->getStorage('file');
+    foreach ($duplicate_uris as $uri) {
+      $fids = $this->database->select('file_managed', 'fm')
+        ->fields('fm', ['fid'])
+        ->condition('uri', $uri)
+        ->orderBy('fid', 'DESC')
+        ->execute()
+        ->fetchCol();
+
+      $keep_fid = array_shift($fids);
+      foreach ($fids as $fid) {
+        if ($file = $storage->load($fid)) {
+          $file->delete();
+          $this->logger()->notice('Deleted duplicate file @fid for @uri', [
+            '@fid' => $fid,
+            '@uri' => $uri,
+          ]);
+        }
+      }
+      $this->logger()->notice('Kept @fid for @uri', ['@fid' => $keep_fid, '@uri' => $uri]);
+    }
+    $this->logger()->notice('Duplicate cleanup complete.');
+  }
+
+}


### PR DESCRIPTION
## Summary
- add Drush command to purge duplicate file_managed rows
- document the dedupe command in the README

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc821ebc883319edd922e6dac8349