### PR TITLE
Return adoption result and errors

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -400,19 +400,27 @@ class FileScanner {
      * @param string[] $file_uris
      *   Array of file URIs (public://...) to adopt.
      *
-     * @return int
-     *   The number of newly created items.
+     * @return array
+     *   An associative array with the keys:
+     *   - count: The number of successfully adopted files.
+     *   - errors: A list of error message strings for files that failed to be
+     *     adopted.
      */
-    public function adoptFiles(array $file_uris) {
+    public function adoptFiles(array $file_uris): array {
         $this->loadManagedUris();
         $count = 0;
+        $errors = [];
         foreach ($file_uris as $uri) {
             if ($this->adoptFile($uri)) {
                 $count++;
                 $this->managedUris[$uri] = TRUE;
             }
+            else {
+                $errors[] = "Failed to adopt file {$uri}.";
+            }
         }
-        return $count;
+
+        return ['count' => $count, 'errors' => $errors];
     }
 
     /**

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -194,32 +194,13 @@ class FileAdoptionForm extends ConfigFormBase {
       $results = $form_state->get('scan_results') ?? [];
       $uris = array_unique($results['to_manage'] ?? []);
       if ($uris) {
-        $count = $this->fileScanner->adoptFiles($uris);
-        if ($count > 0) {
-          $this->messenger()->addStatus($this->t('@count file(s) adopted.', ['@count' => $count]));
+        $result = $this->fileScanner->adoptFiles($uris);
+        if ($result['count'] > 0) {
+          $this->messenger()->addStatus($this->t('@count file(s) adopted.', ['@count' => $result['count']]));
         }
-        else {
-          $logger = \Drupal::service('logger.factory')->get('file_adoption');
-          $logs = [];
-          if (method_exists($logger, 'get')) {
-            $logs = $logger->get();
-          }
-          elseif (method_exists($logger, 'getLogs')) {
-            $logs = $logger->getLogs();
-          }
-          if ($logs) {
-            $recent = array_slice($logs, -3);
-            foreach ($recent as $entry) {
-              if (is_array($entry) && isset($entry['message'])) {
-                $this->messenger()->addError($entry['message']);
-              }
-              elseif (is_string($entry)) {
-                $this->messenger()->addError($entry);
-              }
-            }
-          }
-          else {
-            $this->messenger()->addError($this->t('File adoption failed. Check logs for details.'));
+        if (!empty($result['errors'])) {
+          foreach ($result['errors'] as $message) {
+            $this->messenger()->addError($message);
           }
         }
       }


### PR DESCRIPTION
## Summary
- return more info from `FileScanner::adoptFiles`
- show any adoption errors in `FileAdoptionForm`

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: RecursiveDirectoryIterator failed to open directory)*

------
https://chatgpt.com/codex/tasks/task_e_685bd232792883318b31212a57c2faf3