### PR TITLE
Disable Scan button until preview completes

### DIFF
--- a/js/preview.js
+++ b/js/preview.js
@@ -7,12 +7,23 @@
       const url = drupalSettings.file_adoption.preview_url;
       const wrapper = document.getElementById('file-adoption-preview');
       const details = document.getElementById('file-adoption-preview-wrapper');
+      const scanButton = document.querySelector('input[name="scan"]');
       if (!url || !wrapper) {
         return;
       }
 
+      if (scanButton) {
+        scanButton.disabled = true;
+      }
+
       const maxFailures = 3;
       let failureCount = 0;
+
+      function enableScanButton() {
+        if (scanButton) {
+          scanButton.disabled = false;
+        }
+      }
 
       function handleFailure(error) {
         failureCount += 1;
@@ -22,6 +33,7 @@
         if (failureCount >= maxFailures) {
           wrapper.textContent = Drupal.t('Unable to load preview. Please try again later.');
           clearInterval(intervalId);
+          enableScanButton();
         }
       }
 
@@ -38,6 +50,7 @@
                 }
               }
               clearInterval(intervalId);
+              enableScanButton();
             }
             else {
               handleFailure('Invalid response');


### PR DESCRIPTION
## Summary
- disable "Scan Now" until preview loading finishes

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: RecursiveDirectoryIterator::__construct vendor/drupal/modules: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685bd32eeafc8331ab580010ed01d6c3