### PR TITLE
Remove jquery dependency from preview library

### DIFF
--- a/file_adoption.libraries.yml
+++ b/file_adoption.libraries.yml
@@ -3,4 +3,3 @@ preview:
     js/preview.js: {}
   dependencies:
     - core/drupal
-    - core/jquery


### PR DESCRIPTION
## Summary
- remove core/jquery from file_adoption.libraries.yml because preview.js doesn't use jQuery

## Testing
- `drush cr` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfaceed9c8331a19f6845d236f9ec