### PR TITLE
Fix adoptFile return type

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -432,7 +432,7 @@ class FileScanner {
      * @return bool
      *   TRUE if a new file entity was created, FALSE otherwise.
      */
-    public function adoptFile(string $uri) {
+    public function adoptFile(string $uri): bool {
 
         try {
             if (!$this->managedLoaded) {


### PR DESCRIPTION
## Summary
- declare a bool return type for FileScanner::adoptFile

## Testing
- `composer install --no-interaction`
- `./vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: Failed to open directory)*

------
https://chatgpt.com/codex/tasks/task_e_685bfb53215c8331b4a52749d8a1933d