### PR TITLE
Add webform ignore pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ for files that are not tracked by Drupal's `file_managed` table. Identified
 The configuration form offers the following options:
 
 - **Ignore Patterns** – Comma or newline separated patterns (relative to
-  `public://`) that should be skipped when scanning.
+  `public://`) that should be skipped when scanning. The default list now
+  includes `webform/*` alongside directories such as `asset_injector/*` and
+  `webforms/*`.
 - **Enable Adoption** – When checked, cron will automatically adopt orphaned
   files using the configured settings.
 - **Items per cron run** – Maximum number of files processed and displayed per

--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -10,5 +10,6 @@ ignore_patterns: |
   styles/*
   thousand/testfiles/*1.txt
   webforms/*
+  webform/*
 enable_adoption: false
 items_per_run: 20

--- a/file_adoption.install
+++ b/file_adoption.install
@@ -10,3 +10,18 @@ function file_adoption_update_10001() {
   }
   return t('Added items_per_run setting.');
 }
+
+/**
+ * Adds the webform directory to default ignore patterns.
+ */
+function file_adoption_update_10002() {
+  $config = \Drupal::configFactory()->getEditable('file_adoption.settings');
+  $patterns = $config->get('ignore_patterns') ?? '';
+  // Only add the pattern if it doesn't already exist.
+  if (strpos($patterns, "webform/*") === FALSE) {
+    $patterns = trim($patterns);
+    $patterns = $patterns === '' ? 'webform/*' : $patterns . "\nwebform/*";
+    $config->set('ignore_patterns', $patterns)->save();
+  }
+  return t('Added webform/* ignore pattern.');
+}


### PR DESCRIPTION
## Summary
- add `webform/*` to default ignore patterns
- document new pattern in README
- provide update hook so existing sites get new pattern

## Testing
- `composer install` *(fails: composer not found)*
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685bfc67a5948331a8b99d682775192c