### PR TITLE
Add batch scanning with resume

### DIFF
--- a/file_adoption.module
+++ b/file_adoption.module
@@ -10,6 +10,11 @@
  */
 function file_adoption_cron() {
   $config = \Drupal::config('file_adoption.settings');
+  // Resume any pending scan batches.
+  if (\Drupal::state()->get('file_adoption.scan_progress')) {
+    $context = [];
+    file_adoption_scan_batch_step($context);
+  }
   if ($config->get('enable_adoption')) {
     /** @var \Drupal\file_adoption\FileScanner $scanner */
     $scanner = \Drupal::service('file_adoption.file_scanner');
@@ -18,5 +23,51 @@ function file_adoption_cron() {
       $limit = 500;
     }
     $scanner->scanAndProcess(TRUE, $limit);
+  }
+}
+
+/**
+ * Batch operation for scanning files in chunks.
+ */
+function file_adoption_scan_batch_step(array &$context) {
+  $state = \Drupal::state();
+  /** @var \Drupal\file_adoption\FileScanner $scanner */
+  $scanner = \Drupal::service('file_adoption.file_scanner');
+
+  $progress = $state->get('file_adoption.scan_progress') ?: [
+    'resume' => '',
+    'result' => ['files' => 0, 'orphans' => 0, 'to_manage' => []],
+  ];
+
+  $limit = (int) \Drupal::config('file_adoption.settings')->get('items_per_run');
+  if ($limit > 500) {
+    $limit = 500;
+  }
+
+  $chunk = $scanner->scanChunk($progress['resume'], $limit);
+  $progress['resume'] = $chunk['resume'];
+  $progress['result']['files'] += $chunk['files'];
+  $progress['result']['orphans'] += $chunk['orphans'];
+  $progress['result']['to_manage'] = array_merge($progress['result']['to_manage'], $chunk['to_manage']);
+
+  if ($progress['resume'] === '') {
+    $context['finished'] = 1;
+    $context['results'] = $progress['result'];
+    $state->set('file_adoption.scan_results', $progress['result']);
+    $state->delete('file_adoption.scan_progress');
+  }
+  else {
+    $context['message'] = t('Processed @count files', ['@count' => $progress['result']['files']]);
+    $state->set('file_adoption.scan_progress', $progress);
+    $context['finished'] = 0;
+  }
+}
+
+/**
+ * Batch finished callback.
+ */
+function file_adoption_scan_batch_finished($success, array $results, array $operations) {
+  if ($success) {
+    \Drupal::messenger()->addStatus(t('Scan complete: @count file(s) found. Counts are limited by "Items per cron run".', ['@count' => $results['files']]));
   }
 }

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -36,11 +36,15 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('state')
     );
     $form_object->submitForm($form, $form_state);
 
-    $results = $form_state->get('scan_results');
+    $context = [];
+    file_adoption_scan_batch_step($context);
+
+    $results = $this->container->get('state')->get('file_adoption.scan_results');
     $this->assertEquals(['public://example.txt'], $results['to_manage']);
   }
 
@@ -66,9 +70,15 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('state')
     );
     $form_object->submitForm($form, $form_state);
+
+    do {
+      $context = [];
+      file_adoption_scan_batch_step($context);
+    } while (empty($context['finished']));
 
     // Build the form again to inspect the rendered list.
     $form_state->setTriggeringElement([]);
@@ -159,7 +169,8 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('state')
     );
     $form_object->submitForm($form, $form_state);
 


### PR DESCRIPTION
## Summary
- enable batch-based scanning in `FileAdoptionForm`
- support progress storage and resume token
- resume batches during cron runs
- provide new `scanChunk()` method in `FileScanner`
- adjust kernel tests for batch scanning

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2990c58c8331ba96ff4dd5a1c56f