### PR TITLE
Implement incremental cron scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Changes are stored in `file_adoption.settings`.
 
 When *Enable Adoption* is active, the module's `hook_cron()` implementation runs
 the file scanner during cron to register any discovered orphans automatically.
+Scanning progress is stored between cron runs so that only a portion of the
+public files directory is processed on each execution. After the entire directory
+has been scanned the offset resets and the cycle begins again.
 
 ## Manual Scanning
 

--- a/file_adoption.module
+++ b/file_adoption.module
@@ -10,19 +10,35 @@
  */
 function file_adoption_cron() {
   $config = \Drupal::config('file_adoption.settings');
-  // Resume any pending scan batches.
-  if (\Drupal::state()->get('file_adoption.scan_progress')) {
+  $state = \Drupal::state();
+
+  // Resume any pending scan batches from the configuration form.
+  if ($state->get('file_adoption.scan_progress')) {
     $context = [];
     file_adoption_scan_batch_step($context);
   }
-  if ($config->get('enable_adoption')) {
-    /** @var \Drupal\file_adoption\FileScanner $scanner */
-    $scanner = \Drupal::service('file_adoption.file_scanner');
-    $limit = (int) $config->get('items_per_run');
-    if ($limit > 500) {
-      $limit = 500;
-    }
-    $scanner->scanAndProcess(TRUE, $limit);
+
+  $limit = (int) $config->get('items_per_run');
+  if ($limit > 500) {
+    $limit = 500;
+  }
+
+  /** @var \Drupal\file_adoption\FileScanner $scanner */
+  $scanner = \Drupal::service('file_adoption.file_scanner');
+
+  // Resume incremental cron scanning using the stored offset.
+  $resume = $state->get('file_adoption.cron_offset') ?: '';
+  $chunk = $scanner->scanChunk($resume, $limit);
+
+  if ($config->get('enable_adoption') && !empty($chunk['to_manage'])) {
+    $scanner->adoptFiles($chunk['to_manage']);
+  }
+
+  if ($chunk['resume'] === '') {
+    $state->delete('file_adoption.cron_offset');
+  }
+  else {
+    $state->set('file_adoption.cron_offset', $chunk['resume']);
   }
 }
 

--- a/tests/src/Kernel/FileAdoptionCronTest.php
+++ b/tests/src/Kernel/FileAdoptionCronTest.php
@@ -34,6 +34,7 @@ class FileAdoptionCronTest extends KernelTestBase {
 
     // First cron run should adopt only one file.
     file_adoption_cron();
+    $this->assertNotEmpty($this->container->get('state')->get('file_adoption.cron_offset'));
     /** @var FileScanner $scanner */
     $scanner = $this->container->get('file_adoption.file_scanner');
     $result = $scanner->scanAndProcess(FALSE);
@@ -41,6 +42,7 @@ class FileAdoptionCronTest extends KernelTestBase {
 
     // Second cron run should adopt the remaining file.
     file_adoption_cron();
+    $this->assertNull($this->container->get('state')->get('file_adoption.cron_offset'));
     $result = $scanner->scanAndProcess(FALSE);
     $this->assertEquals(0, $result['orphans']);
   }


### PR DESCRIPTION
## Summary
- store a cron resume offset between runs
- update `file_adoption_cron()` to scan a chunk using the offset
- wipe the offset once the scan reaches the end
- document cron resume behaviour
- test offset handling

## Testing
- `apt-get install -y composer` *(install composer)*
- `apt-get install -y phpunit` *(install phpunit)*
- `composer install` *(fails: Could not authenticate against github.com)*
- `phpunit --configuration phpunit.xml.dist` *(fails: Cannot open bootstrap.php)*

------
https://chatgpt.com/codex/tasks/task_e_685c2c348e708331a2b326644483b4d4