### PR TITLE
Persist managed file list across batch requests

### DIFF
--- a/file_adoption.services.yml
+++ b/file_adoption.services.yml
@@ -10,6 +10,7 @@ services:
       - '@database'
       - '@config.factory'
       - '@logger.channel.file_adoption'
+      - '@state'
   file_adoption.preview_controller:
     class: 'Drupal\file_adoption\Controller\PreviewController'
     arguments:


### PR DESCRIPTION
## Summary
- cache managed URIs in Drupal state to avoid DB queries during batches
- inject `state` service into `FileScanner`
- persist cache at the end of each `scanChunk` call

## Testing
- `vendor/bin/phpunit --version` *(fails: command not found)*
- `phpunit -c phpunit.xml.dist tests/src/Kernel/FileScannerTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5ce755048331aaf5aee89627479f