### PR TITLE
Implement uninstall cleanup

### DIFF
--- a/file_adoption.install
+++ b/file_adoption.install
@@ -25,3 +25,14 @@ function file_adoption_update_10002() {
   }
   return t('Added webform/* ignore pattern.');
 }
+
+/**
+ * Implements hook_uninstall().
+ */
+function file_adoption_uninstall() {
+  $state = \Drupal::state();
+  $state->delete('file_adoption.managed_cache');
+  $state->delete('file_adoption.scan_results');
+  $state->delete('file_adoption.scan_progress');
+  $state->delete('file_adoption.cron_offset');
+}


### PR DESCRIPTION
## Summary
- add hook_uninstall implementation
- remove module state entries during uninstall

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c674cb3708331a9d5f84ff188fa0c