### PR TITLE
Add OpenAI project config and setup script

### DIFF
--- a/.openai/project.json
+++ b/.openai/project.json
@@ -1,0 +1,4 @@
+{
+  "setup_script": "setup.sh",
+  "entry_point": "vendor/bin/phpunit --configuration phpunit.xml.dist"
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+composer install --no-interaction


### PR DESCRIPTION
## Summary
- add `.openai/project.json` with setup script and PHPUnit entry point
- add `setup.sh` helper script

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6f1356f48331865ba437a2bc19e3