### PR TITLE
Fix resume scanning skip logic

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -343,8 +343,9 @@ class FileScanner {
             if ($skipping) {
                 if ($relative_path === $resume) {
                     $skipping = FALSE;
+                } else {
+                    continue;
                 }
-                continue;
             }
 
             if ($limit > 0 && count($results['to_manage']) >= $limit) {


### PR DESCRIPTION
## Summary
- ensure the resume file is processed rather than skipped when scanning

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist --testsuite kernel` *(fails: RecursiveDirectoryIterator::__construct(/workspace/file_adoption/vendor/drupal/modules): Failed to open directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c703177ac8331b6102707db832148