### PR TITLE
Add drush.services.yml for command discovery

### DIFF
--- a/drush.services.yml
+++ b/drush.services.yml
@@ -1,0 +1,9 @@
+services:
+  file_adoption.commands:
+    class: Drupal\file_adoption\Commands\FileAdoptionCommands
+    tags:
+      - { name: drush.command }
+  file_adoption.scan_commands:
+    class: Drupal\file_adoption\Commands\FileAdoptionScanCommands
+    tags:
+      - { name: drush.command }


### PR DESCRIPTION
## Summary
- add Drush services configuration

After enabling the module, run `drush cr` so Drush recognizes the commands.

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: `vendor/bin/phpunit` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c7ff1f4048331a4a9e20644e51282