### PR TITLE
Fix Drush command dependency injection

### DIFF
--- a/drush.services.yml
+++ b/drush.services.yml
@@ -1,9 +1,15 @@
 services:
   file_adoption.commands:
     class: Drupal\file_adoption\Commands\FileAdoptionCommands
+    arguments:
+      - '@database'
+      - '@entity_type.manager'
     tags:
       - { name: drush.command }
   file_adoption.scan_commands:
     class: Drupal\file_adoption\Commands\FileAdoptionScanCommands
+    arguments:
+      - '@file_adoption.file_scanner'
+      - '@config.factory'
     tags:
       - { name: drush.command }


### PR DESCRIPTION
## Summary
- supply dependencies for FileAdoptionCommands and FileAdoptionScanCommands

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c7ca9ca3c8331aadb570559c4efb5