### PR TITLE
Add quick and batch scan actions

### DIFF
--- a/js/preview.js
+++ b/js/preview.js
@@ -7,7 +7,7 @@
       const url = drupalSettings.file_adoption.preview_url;
       const wrapper = document.getElementById('file-adoption-preview');
       const details = document.getElementById('file-adoption-preview-wrapper');
-      const scanButton = document.querySelector('input[name="scan"]');
+      const scanButtons = document.querySelectorAll('input[name="quick_scan"], input[name="batch_scan"]');
       if (!url || !wrapper) {
         return;
       }
@@ -15,10 +15,10 @@
       const maxFailures = 3;
       let failureCount = 0;
 
-      function enableScanButton() {
-        if (scanButton) {
-          scanButton.disabled = false;
-        }
+      scanButtons.forEach((btn) => { btn.disabled = true; });
+
+      function enableScanButtons() {
+        scanButtons.forEach((btn) => { btn.disabled = false; });
       }
 
       function handleFailure(error) {
@@ -29,7 +29,7 @@
         if (failureCount >= maxFailures) {
           wrapper.textContent = Drupal.t('Unable to load preview. Please try again later.');
           clearInterval(intervalId);
-          enableScanButton();
+          enableScanButtons();
         }
       }
 
@@ -46,7 +46,7 @@
                 }
               }
               clearInterval(intervalId);
-              enableScanButton();
+              enableScanButtons();
             }
             else {
               handleFailure('Invalid response');

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -22,7 +22,7 @@ class FileAdoptionFormTest extends KernelTestBase {
   /**
    * Tests scanning action in the form submit handler.
    */
-  public function testFormScan() {
+  public function testQuickScan() {
     $public = $this->container->get('file_system')->getTempDirectory();
     $this->config('system.file')->set('path.public', $public)->save();
 
@@ -32,7 +32,7 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form = [];
     $form_state = new FormState();
-    $form_state->setTriggeringElement(['#name' => 'scan']);
+    $form_state->setTriggeringElement(['#name' => 'quick_scan']);
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
@@ -64,7 +64,7 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form = [];
     $form_state = new FormState();
-    $form_state->setTriggeringElement(['#name' => 'scan']);
+    $form_state->setTriggeringElement(['#name' => 'quick_scan']);
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
@@ -86,7 +86,39 @@ class FileAdoptionFormTest extends KernelTestBase {
   /**
    * Ensures long scans fall back to the batch process.
    */
-  public function testFormScanFallback() {
+  public function testBatchScan() {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save();
+
+    file_put_contents("$public/example.txt", 'foo');
+
+    $this->config('file_adoption.settings')->set('ignore_patterns', '')->save();
+
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setTriggeringElement(['#name' => 'batch_scan']);
+
+    $form_object = new FileAdoptionForm(
+      $this->container->get('file_adoption.file_scanner'),
+      $this->container->get('file_system'),
+      $this->container->get('state')
+    );
+    $form_object->submitForm($form, $form_state);
+
+    $this->assertNull($form_state->get('scan_results'));
+    $this->assertNotEmpty($this->container->get('state')->get('file_adoption.scan_progress'));
+
+    $context = [];
+    file_adoption_scan_batch_step($context);
+
+    $results = $this->container->get('state')->get('file_adoption.scan_results');
+    $this->assertEquals(['public://example.txt'], $results['to_manage']);
+  }
+
+  /**
+   * Ensures quick scans do not start a batch when time limit is exceeded.
+   */
+  public function testQuickScanTimeout() {
     $public = $this->container->get('file_system')->getTempDirectory();
     $this->config('system.file')->set('path.public', $public)->save();
 
@@ -98,7 +130,7 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form = [];
     $form_state = new FormState();
-    $form_state->setTriggeringElement(['#name' => 'scan']);
+    $form_state->setTriggeringElement(['#name' => 'quick_scan']);
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
@@ -110,13 +142,7 @@ class FileAdoptionFormTest extends KernelTestBase {
     putenv('FILE_ADOPTION_SCAN_LIMIT');
 
     $this->assertNull($form_state->get('scan_results'));
-    $this->assertNotEmpty($this->container->get('state')->get('file_adoption.scan_progress'));
-
-    $context = [];
-    file_adoption_scan_batch_step($context);
-
-    $results = $this->container->get('state')->get('file_adoption.scan_results');
-    $this->assertEquals(['public://example.txt'], $results['to_manage']);
+    $this->assertNull($this->container->get('state')->get('file_adoption.scan_progress'));
   }
 
   /**


### PR DESCRIPTION
## Summary
- add Quick Scan and Batch Scan buttons
- update the form submit handler for the new actions
- disable both scan buttons until preview data loads
- expand kernel tests for quick scan timeout and batch scanning

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist tests/src/Kernel/FileAdoptionFormTest.php --stop-on-failure` *(fails: `vendor/bin/phpunit` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1a88672883319466ca8815a78979