### PR TITLE
Fix batch scan callback not found

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -242,7 +242,11 @@ class FileAdoptionForm extends ConfigFormBase {
       $batch = [
         'title' => $this->t('Scanning for orphaned files'),
         'operations' => [
-          ['file_adoption_scan_batch_step', []],
+          [
+            'file_adoption_scan_batch_step',
+            [],
+            ['file' => drupal_get_path('module', 'file_adoption') . '/file_adoption.module'],
+          ],
         ],
         'finished' => 'file_adoption_scan_batch_finished',
       ];


### PR DESCRIPTION
## Summary
- ensure batch operations include the module file so callbacks are loaded

## Testing
- `phpunit -c phpunit.xml.dist tests/src/Kernel/FileAdoptionFormTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d3bd5a334833187d0cfe86117470a