### PR TITLE
Raise cron run limit to 5000

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The configuration form offers the following options:
 - **Enable Adoption** – When checked, cron will automatically adopt orphaned
   files using the configured settings.
 - **Items per cron run** – Maximum number of files processed and displayed per
-  scan or cron run. Defaults to 20 and capped at 500.
+  scan or cron run. Defaults to 20 and capped at 5000.
 
 Changes are stored in `file_adoption.settings`.
 
@@ -54,7 +54,7 @@ To run a scan on demand:
 The `items_per_run` setting defines how many files are scanned in each batch.
 Larger values mean more files are processed before control returns to the
 browser, reducing the number of passes needed to complete a scan. The default is
-20 but the value can be raised up to 500. Increasing this limit is especially
+20 but the value can be raised up to 5000. Increasing this limit is especially
 helpful during manual scans where higher batch sizes dramatically shorten the
 time it takes for results to appear.
 
@@ -62,7 +62,7 @@ time it takes for results to appear.
 
 Each scan runs in a series of batch steps, with the `items_per_run` value
 controlling how many files are inspected on each step. Raising this value up to
-the 500 cap can speed up scans on systems with fast storage by cutting down on
+the 5000 cap can speed up scans on systems with fast storage by cutting down on
 the number of HTTP requests required. Lower values, on the other hand, reduce
 the per-request workload which is useful on slower disks or shared hosting.
 When quick scanning is available, the module prefers that method and falls back to the batch process governed by this setting.

--- a/file_adoption.module
+++ b/file_adoption.module
@@ -19,8 +19,8 @@ function file_adoption_cron() {
   }
 
   $limit = (int) $config->get('items_per_run');
-  if ($limit > 500) {
-    $limit = 500;
+  if ($limit > 5000) {
+    $limit = 5000;
   }
 
   /** @var \Drupal\file_adoption\FileScanner $scanner */
@@ -56,8 +56,8 @@ function file_adoption_scan_batch_step(array &$context) {
   ];
 
   $limit = (int) \Drupal::config('file_adoption.settings')->get('items_per_run');
-  if ($limit > 500) {
-    $limit = 500;
+  if ($limit > 5000) {
+    $limit = 5000;
   }
 
   $chunk = $scanner->scanChunk($progress['resume'], $limit);

--- a/src/Commands/FileAdoptionScanCommands.php
+++ b/src/Commands/FileAdoptionScanCommands.php
@@ -52,7 +52,7 @@ class FileAdoptionScanCommands extends DrushCommands {
    * @aliases fad-scan
    *
    * @option adopt Adopt discovered files immediately.
-   * @option limit Maximum number of files to process (capped at 500).
+   * @option limit Maximum number of files to process (capped at 5000).
    *
    * @usage drush file_adoption:scan
    *   List orphaned files that would be adopted.
@@ -68,8 +68,8 @@ class FileAdoptionScanCommands extends DrushCommands {
     if ($limit < 0) {
       $limit = 0;
     }
-    elseif ($limit > 500) {
-      $limit = 500;
+    elseif ($limit > 5000) {
+      $limit = 5000;
     }
 
     if ($adopt) {

--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -254,7 +254,7 @@ class FileScanner {
      * @return array
      *   Associative array with keys 'files', 'orphans' and 'to_manage'.
      */
-    public function scanWithLists(int $limit = 500) {
+    public function scanWithLists(int $limit = 5000) {
         $results = ['files' => 0, 'orphans' => 0, 'to_manage' => []];
         $patterns = $this->getIgnorePatterns();
         // Preload managed URIs for quick checks.
@@ -322,7 +322,7 @@ class FileScanner {
      *   Associative array with keys 'files', 'orphans', 'to_manage' and 'resume'.
      *   The 'resume' value will be empty when the scan is complete.
      */
-    public function scanChunk(string $resume = '', int $limit = 500): array {
+    public function scanChunk(string $resume = '', int $limit = 5000): array {
         $results = ['files' => 0, 'orphans' => 0, 'to_manage' => [], 'resume' => ''];
         $patterns = $this->getIgnorePatterns();
         $this->loadManagedUris($resume === '');

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -100,15 +100,15 @@ class FileAdoptionForm extends ConfigFormBase {
     if (empty($items_per_run)) {
       $items_per_run = 20;
     }
-    elseif ($items_per_run > 500) {
-      $items_per_run = 500;
+    elseif ($items_per_run > 5000) {
+      $items_per_run = 5000;
     }
     $form['items_per_run'] = [
       '#type' => 'number',
       '#title' => $this->t('Items per cron run'),
       '#default_value' => $items_per_run,
       '#min' => 1,
-      '#max' => 500,
+      '#max' => 5000,
     ];
 
 
@@ -202,8 +202,8 @@ class FileAdoptionForm extends ConfigFormBase {
     if ($items_per_run <= 0) {
       $items_per_run = 20;
     }
-    elseif ($items_per_run > 500) {
-      $items_per_run = 500;
+    elseif ($items_per_run > 5000) {
+      $items_per_run = 5000;
     }
     $this->config('file_adoption.settings')
       ->set('ignore_patterns', $form_state->getValue('ignore_patterns'))

--- a/tests/src/Kernel/FileAdoptionCronTest.php
+++ b/tests/src/Kernel/FileAdoptionCronTest.php
@@ -54,13 +54,13 @@ class FileAdoptionCronTest extends KernelTestBase {
     $public = $this->container->get('file_system')->getTempDirectory();
     $this->config('system.file')->set('path.public', $public)->save();
 
-    for ($i = 0; $i < 600; $i++) {
+    for ($i = 0; $i < 5100; $i++) {
       file_put_contents("$public/$i.txt", 'x');
     }
 
     $this->config('file_adoption.settings')
       ->set('enable_adoption', TRUE)
-      ->set('items_per_run', 999)
+      ->set('items_per_run', 99999)
       ->save();
 
     file_adoption_cron();

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -217,12 +217,12 @@ class FileAdoptionFormTest extends KernelTestBase {
   }
 
   /**
-   * Ensures the items per run value is capped at 500.
+   * Ensures the items per run value is capped at 5000.
    */
   public function testItemsPerRunCap() {
     $form = [];
     $form_state = new FormState();
-    $form_state->setValue('items_per_run', 999);
+    $form_state->setValue('items_per_run', 99999);
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
@@ -231,7 +231,7 @@ class FileAdoptionFormTest extends KernelTestBase {
     );
     $form_object->submitForm($form, $form_state);
 
-    $this->assertEquals(500, $this->config('file_adoption.settings')->get('items_per_run'));
+    $this->assertEquals(5000, $this->config('file_adoption.settings')->get('items_per_run'));
   }
 
 }


### PR DESCRIPTION
## Summary
- extend the `items_per_run` cap from 500 to 5000
- update form defaults and validation
- adjust Drush command help and cap
- bump scanner defaults
- refresh tests for new limit
- document new limit

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d449a30f483318b7f34bc9a37fc97