### PR TITLE
Fix invalid render array key

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -129,7 +129,7 @@ class FileAdoptionForm extends ConfigFormBase {
       $form['#attached']['drupalSettings']['file_adoption']['preview_title'] = $this->t('Public Directory Contents Preview');
     }
     else {
-      $form['preview']['description'] = $this->t('Run a quick scan or batch scan to view a preview of the public directory.');
+      $form['preview']['#description'] = $this->t('Run a quick scan or batch scan to view a preview of the public directory.');
     }
 
 


### PR DESCRIPTION
## Summary
- fix invalid render array key in `FileAdoptionForm`

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: Failed to open directory)*

------
https://chatgpt.com/codex/tasks/task_e_685d60df71388331a15614793e808617