### PR TITLE
Move help text below buttons

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -153,7 +153,7 @@ class FileAdoptionForm extends ConfigFormBase {
       '#button_type' => 'secondary',
       '#name' => 'batch_scan',
     ];
-    $form['actions']['scan_help'] = [
+    $form['scan_help'] = [
       '#markup' => '<div class="description">' . $this->t('If scanning the filesystem takes more than 20 seconds, a batch scan is recommended.') . '</div>',
     ];
 


### PR DESCRIPTION
## Summary
- ensure the scan help text appears beneath the action button section

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d786735b48331b7be1fe8e2fdb372