### PR TITLE
Add progress details to batch scan

### DIFF
--- a/file_adoption.module
+++ b/file_adoption.module
@@ -73,7 +73,15 @@ function file_adoption_scan_batch_step(array &$context) {
     $state->delete('file_adoption.scan_progress');
   }
   else {
-    $context['message'] = t('Processed @count files', ['@count' => $progress['result']['files']]);
+    $values = [
+      '@count' => $progress['result']['files'],
+      '@path' => $chunk['last_path'] ?? $progress['resume'],
+    ];
+    $message = t('Processed @count files (last path: @path)', $values);
+    if (!empty($chunk['errors'])) {
+      $message .= ' ' . t('Errors: @errors', ['@errors' => implode('; ', $chunk['errors'])]);
+    }
+    $context['message'] = $message;
     $state->set('file_adoption.scan_progress', $progress);
     $context['finished'] = 0;
   }


### PR DESCRIPTION
## Summary
- expose `last_path` and `errors` from FileScanner::scanChunk
- show last processed path and any errors in the batch status message

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685d883e03708331b67bc105fb2acb03