### PR TITLE
Remove obsolete webforms ignore pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ The configuration form offers the following options:
 
 - **Ignore Patterns** – Comma or newline separated patterns (relative to
   `public://`) that should be skipped when scanning. The default list now
-  includes `webform/*` alongside directories such as `asset_injector/*` and
-  `webforms/*`.
+  includes `webform/*` alongside directories such as `asset_injector/*`.
 - **Enable Adoption** – When checked, cron will automatically adopt orphaned
   files using the configured settings.
 - **Items per cron run** – Maximum number of files processed and displayed per

--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -9,7 +9,6 @@ ignore_patterns: |
   private/*
   styles/*
   thousand/testfiles/*1.txt
-  webforms/*
   webform/*
 enable_adoption: false
 items_per_run: 100


### PR DESCRIPTION
## Summary
- update readme docs to no longer mention `webforms/*`
- remove `webforms/*` from the default settings

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685d968a39348331840667cc92d1e2f3