### PR TITLE
Add URI filter and config save handling

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -120,6 +120,40 @@ class FileScanner {
     }
 
     /**
+     * Filters file URIs against configured ignore patterns.
+     *
+     * @param string[] $uris
+     *   Array of file URIs (public://...) to check.
+     *
+     * @return string[]
+     *   URIs that do not match any ignore pattern.
+     */
+    public function filterUris(array $uris): array {
+        $patterns = $this->getIgnorePatterns();
+        $filtered = [];
+        foreach ($uris as $uri) {
+            $relative = str_replace('public://', '', $uri);
+
+            if (preg_match('/(^|\/)(\.|\.{2})/', $relative)) {
+                continue;
+            }
+
+            $ignored = FALSE;
+            foreach ($patterns as $pattern) {
+                if ($pattern !== '' && fnmatch($pattern, $relative)) {
+                    $ignored = TRUE;
+                    break;
+                }
+            }
+            if (!$ignored) {
+                $filtered[] = $uri;
+            }
+        }
+
+        return $filtered;
+    }
+
+    /**
      * Loads all managed file URIs into the local cache.
      *
      * @param bool $reset

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -303,6 +303,15 @@ class FileAdoptionForm extends ConfigFormBase {
       $form_state->setRebuild(TRUE);
     }
     else {
+      $results = $this->state->get('file_adoption.scan_results');
+      if ($results && !empty($results['to_manage'])) {
+        $filtered = $this->fileScanner->filterUris($results['to_manage']);
+        $results['to_manage'] = array_values($filtered);
+        $this->state->set('file_adoption.scan_results', $results);
+        $form_state->set('scan_results', $results);
+        $form_state->setRebuild(TRUE);
+      }
+
       $this->messenger()->addStatus($this->t('Configuration saved.'));
     }
   }

--- a/tests/src/Kernel/RefilterResultsOnSaveTest.php
+++ b/tests/src/Kernel/RefilterResultsOnSaveTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\Tests\file_adoption\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\file_adoption\Form\FileAdoptionForm;
+use Drupal\Core\Form\FormState;
+
+/**
+ * Tests re-filtering scan results on configuration save.
+ *
+ * @group file_adoption
+ */
+class RefilterResultsOnSaveTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'file', 'file_adoption'];
+
+  /**
+   * Ensures saved scan results are filtered when ignore patterns change.
+   */
+  public function testResultsFilteredOnSave() {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save();
+
+    file_put_contents("$public/keep.txt", 'a');
+    file_put_contents("$public/skip.txt", 'b');
+
+    $this->config('file_adoption.settings')->set('ignore_patterns', '')->save();
+
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setTriggeringElement(['#name' => 'quick_scan']);
+
+    $form_object = new FileAdoptionForm(
+      $this->container->get('file_adoption.file_scanner'),
+      $this->container->get('file_system'),
+      $this->container->get('state'),
+    );
+    $form_object->submitForm($form, $form_state);
+
+    $state = $this->container->get('state');
+    $results = $state->get('file_adoption.scan_results');
+    sort($results['to_manage']);
+    $this->assertEquals([
+      'public://keep.txt',
+      'public://skip.txt',
+    ], $results['to_manage']);
+
+    // Update ignore patterns to exclude skip.txt and save configuration.
+    $form_state2 = new FormState();
+    $form_state2->setValue('ignore_patterns', 'skip.txt');
+    $form_state2->setValue('enable_adoption', 0);
+    $form_state2->setValue('items_per_run', 100);
+    $form_state2->setTriggeringElement(['#name' => 'op']);
+
+    $form_object->submitForm([], $form_state2);
+
+    $filtered = $state->get('file_adoption.scan_results');
+    $this->assertEquals(['public://keep.txt'], $filtered['to_manage']);
+    $this->assertEquals(['public://keep.txt'], $form_state2->get('scan_results')['to_manage']);
+    $this->assertTrue($form_state2->isRebuild());
+  }
+
+}
+


### PR DESCRIPTION
## Summary
- add a helper to filter URIs by ignore patterns
- re-filter scan results on configuration save
- ensure form rebuilds with filtered results
- cover new behavior with kernel test

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d9821986883318aaaa0bf67c73e83