### PR TITLE
Add directory counts to scan results

### DIFF
--- a/file_adoption.module
+++ b/file_adoption.module
@@ -52,7 +52,12 @@ function file_adoption_scan_batch_step(array &$context) {
 
   $progress = $state->get('file_adoption.scan_progress') ?: [
     'resume' => '',
-    'result' => ['files' => 0, 'orphans' => 0, 'to_manage' => []],
+    'result' => [
+      'files' => 0,
+      'orphans' => 0,
+      'to_manage' => [],
+      'dir_counts' => [],
+    ],
   ];
 
   $limit = (int) \Drupal::config('file_adoption.settings')->get('items_per_run');
@@ -65,6 +70,12 @@ function file_adoption_scan_batch_step(array &$context) {
   $progress['result']['files'] += $chunk['files'];
   $progress['result']['orphans'] += $chunk['orphans'];
   $progress['result']['to_manage'] = array_merge($progress['result']['to_manage'], $chunk['to_manage']);
+  foreach ($chunk['dir_counts'] as $dir => $count) {
+    if (!isset($progress['result']['dir_counts'][$dir])) {
+      $progress['result']['dir_counts'][$dir] = 0;
+    }
+    $progress['result']['dir_counts'][$dir] += $count;
+  }
 
   if ($progress['resume'] === '') {
     $context['finished'] = 1;

--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -289,7 +289,12 @@ class FileScanner {
      *   Associative array with keys 'files', 'orphans' and 'to_manage'.
      */
     public function scanWithLists(int $limit = 5000) {
-        $results = ['files' => 0, 'orphans' => 0, 'to_manage' => []];
+        $results = [
+            'files' => 0,
+            'orphans' => 0,
+            'to_manage' => [],
+            'dir_counts' => [],
+        ];
         $patterns = $this->getIgnorePatterns();
         // Preload managed URIs for quick checks.
         $this->loadManagedUris(TRUE);
@@ -330,6 +335,24 @@ class FileScanner {
 
             $results['files']++;
 
+            $dir = dirname($relative_path);
+            if ($dir === '.') {
+                $dir = '';
+            }
+            while (TRUE) {
+                if (!isset($results['dir_counts'][$dir])) {
+                    $results['dir_counts'][$dir] = 0;
+                }
+                $results['dir_counts'][$dir]++;
+                if ($dir === '') {
+                    break;
+                }
+                $dir = dirname($dir);
+                if ($dir === '.') {
+                    $dir = '';
+                }
+            }
+
             $uri = 'public://' . $relative_path;
 
             if (!isset($this->managedUris[$uri])) {
@@ -363,6 +386,7 @@ class FileScanner {
             'files' => 0,
             'orphans' => 0,
             'to_manage' => [],
+            'dir_counts' => [],
             'resume' => '',
             'last_path' => '',
             'errors' => [],
@@ -424,6 +448,24 @@ class FileScanner {
             }
 
             $results['files']++;
+
+            $dir = dirname($relative_path);
+            if ($dir === '.') {
+                $dir = '';
+            }
+            while (TRUE) {
+                if (!isset($results['dir_counts'][$dir])) {
+                    $results['dir_counts'][$dir] = 0;
+                }
+                $results['dir_counts'][$dir]++;
+                if ($dir === '') {
+                    break;
+                }
+                $dir = dirname($dir);
+                if ($dir === '.') {
+                    $dir = '';
+                }
+            }
 
             $uri = 'public://' . $relative_path;
             if (!isset($this->managedUris[$uri])) {

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -240,7 +240,12 @@ class FileAdoptionForm extends ConfigFormBase {
         $this->state->delete('file_adoption.scan_results');
         $this->state->set('file_adoption.scan_progress', [
           'resume' => '',
-          'result' => ['files' => 0, 'orphans' => 0, 'to_manage' => []],
+          'result' => [
+            'files' => 0,
+            'orphans' => 0,
+            'to_manage' => [],
+            'dir_counts' => [],
+          ],
         ]);
         $batch = [
           'title' => $this->t('Scanning for orphaned files'),
@@ -264,7 +269,12 @@ class FileAdoptionForm extends ConfigFormBase {
       $this->state->delete('file_adoption.scan_results');
       $this->state->set('file_adoption.scan_progress', [
         'resume' => '',
-        'result' => ['files' => 0, 'orphans' => 0, 'to_manage' => []],
+        'result' => [
+          'files' => 0,
+          'orphans' => 0,
+          'to_manage' => [],
+          'dir_counts' => [],
+        ],
       ]);
       $batch = [
         'title' => $this->t('Scanning for orphaned files'),

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -43,6 +43,7 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $results = $form_state->get('scan_results');
     $this->assertEquals(['public://example.txt'], $results['to_manage']);
+    $this->assertEquals(['' => 1], $results['dir_counts']);
     $this->assertNull($this->container->get('state')->get('file_adoption.scan_progress'));
   }
 
@@ -115,6 +116,7 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $results = $this->container->get('state')->get('file_adoption.scan_results');
     $this->assertEquals(['public://example.txt'], $results['to_manage']);
+    $this->assertEquals(['' => 1], $results['dir_counts']);
   }
 
   /**

--- a/tests/src/Kernel/FileScannerTest.php
+++ b/tests/src/Kernel/FileScannerTest.php
@@ -43,6 +43,7 @@ class FileScannerTest extends KernelTestBase {
     $this->assertEquals(2, $results['files']);
     $this->assertEquals(1, $results['orphans']);
     $this->assertEquals(['public://example.txt'], $results['to_manage']);
+    $this->assertEquals(['' => 1], $results['dir_counts']);
   }
 
   /**
@@ -90,6 +91,7 @@ class FileScannerTest extends KernelTestBase {
     $this->assertEquals(2, $results['files']);
     $this->assertEquals(2, $results['orphans']);
     $this->assertCount(2, $results['to_manage']);
+    $this->assertEquals(['' => 3], $results['dir_counts']);
   }
 
   /**

--- a/tests/src/Kernel/RefilterResultsOnSaveTest.php
+++ b/tests/src/Kernel/RefilterResultsOnSaveTest.php
@@ -48,6 +48,7 @@ class RefilterResultsOnSaveTest extends KernelTestBase {
       'public://keep.txt',
       'public://skip.txt',
     ], $results['to_manage']);
+    $this->assertEquals(['' => 2], $results['dir_counts']);
 
     // Update ignore patterns to exclude skip.txt and save configuration.
     $form_state2 = new FormState();
@@ -60,6 +61,7 @@ class RefilterResultsOnSaveTest extends KernelTestBase {
 
     $filtered = $state->get('file_adoption.scan_results');
     $this->assertEquals(['public://keep.txt'], $filtered['to_manage']);
+    $this->assertEquals(['' => 1], $filtered['dir_counts']);
     $this->assertEquals(['public://keep.txt'], $form_state2->get('scan_results')['to_manage']);
     $this->assertTrue($form_state2->isRebuild());
   }

--- a/tests/src/Kernel/ScanChunkResumeTest.php
+++ b/tests/src/Kernel/ScanChunkResumeTest.php
@@ -35,10 +35,12 @@ class ScanChunkResumeTest extends KernelTestBase {
     $first = $scanner->scanChunk('', 1);
     $this->assertCount(1, $first['to_manage']);
     $this->assertNotEmpty($first['resume']);
+    $this->assertEquals(['' => 1], $first['dir_counts']);
 
     $second = $scanner->scanChunk($first['resume'], 1);
     $this->assertCount(1, $second['to_manage']);
     $this->assertEquals('', $second['resume']);
+    $this->assertEquals(['' => 1], $second['dir_counts']);
 
     $combined = array_merge($first['to_manage'], $second['to_manage']);
     sort($combined);


### PR DESCRIPTION
## Summary
- extend `FileScanner::scanWithLists()` and `scanChunk()` to record per-directory counts
- merge `dir_counts` in `file_adoption_scan_batch_step()`
- persist results including directory counts in the state
- adjust form batch initialization
- update tests for the new field

## Testing
- `php -l file_adoption.module`
- `php -l src/FileScanner.php`
- `php -l src/Form/FileAdoptionForm.php`
- `php -l tests/src/Kernel/FileAdoptionFormTest.php`
- `php -l tests/src/Kernel/FileScannerTest.php`
- `php -l tests/src/Kernel/RefilterResultsOnSaveTest.php`
- `php -l tests/src/Kernel/ScanChunkResumeTest.php`
- `phpunit -c phpunit.xml.dist` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d993357388331b595626719856d44