### PR TITLE
Update preview to use cached counts

### DIFF
--- a/file_adoption.module
+++ b/file_adoption.module
@@ -68,6 +68,7 @@ function file_adoption_scan_batch_step(array &$context) {
 
   if ($progress['resume'] === '') {
     $context['finished'] = 1;
+    $progress['result']['dir_counts'] = $scanner->countFilesByDirectory();
     $context['results'] = $progress['result'];
     $state->set('file_adoption.scan_results', $progress['result']);
     $state->delete('file_adoption.scan_progress');

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -230,6 +230,7 @@ class FileAdoptionForm extends ConfigFormBase {
       $elapsed = microtime(TRUE) - $start;
 
       if ($elapsed <= $time_limit) {
+        $results['dir_counts'] = $this->fileScanner->countFilesByDirectory();
         $form_state->set('scan_results', $results);
         $this->state->set('file_adoption.scan_results', $results);
         $this->state->delete('file_adoption.scan_progress');

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -162,7 +162,8 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $controller = new PreviewController(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('state')
     );
     $data = json_decode($controller->preview()->getContent(), TRUE);
     $markup = $data['markup'];
@@ -187,7 +188,8 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $controller = new PreviewController(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('state')
     );
     $data = json_decode($controller->preview()->getContent(), TRUE);
     $this->assertEquals(1, $data['count']);
@@ -210,7 +212,8 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $controller = new PreviewController(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('state')
     );
     $data = json_decode($controller->preview()->getContent(), TRUE);
     $this->assertEquals(1, $data['count']);

--- a/tests/src/Kernel/PreviewLargeFilesTest.php
+++ b/tests/src/Kernel/PreviewLargeFilesTest.php
@@ -32,7 +32,8 @@ class PreviewLargeFilesTest extends KernelTestBase {
 
     $controller = new PreviewController(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('state')
     );
     $data = json_decode($controller->preview()->getContent(), TRUE);
 

--- a/tests/src/Kernel/PreviewStoredCountsTest.php
+++ b/tests/src/Kernel/PreviewStoredCountsTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Drupal\Tests\file_adoption\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\file_adoption\Form\FileAdoptionForm;
+use Drupal\file_adoption\Controller\PreviewController;
+use Drupal\Core\Form\FormState;
+
+/**
+ * Tests preview behavior with stored directory counts.
+ *
+ * @group file_adoption
+ */
+class PreviewStoredCountsTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'file', 'file_adoption'];
+
+  /**
+   * Ensures preview uses cached counts.
+   */
+  public function testPreviewUsesStoredCounts() {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save();
+
+    mkdir("$public/a", 0777, TRUE);
+    file_put_contents("$public/a/one.txt", '1');
+    file_put_contents("$public/root.txt", 'r');
+
+    $this->config('file_adoption.settings')->set('ignore_patterns', '')->save();
+
+    // Run a quick scan to populate scan_results with dir_counts.
+    $form_state = new FormState();
+    $form_state->setTriggeringElement(['#name' => 'quick_scan']);
+    $form = [];
+    $form_object = new FileAdoptionForm(
+      $this->container->get('file_adoption.file_scanner'),
+      $this->container->get('file_system'),
+      $this->container->get('state')
+    );
+    $form_object->submitForm($form, $form_state);
+
+    $stored = $this->container->get('state')->get('file_adoption.scan_results');
+    $this->assertNotEmpty($stored['dir_counts']);
+
+    // Add a new file after the scan which should not affect the preview.
+    file_put_contents("$public/new.txt", 'n');
+
+    $controller = new PreviewController(
+      $this->container->get('file_adoption.file_scanner'),
+      $this->container->get('file_system'),
+      $this->container->get('state')
+    );
+    $data = json_decode($controller->preview()->getContent(), TRUE);
+    $this->assertEquals(2, $data['count']);
+  }
+
+  /**
+   * Changing configuration should not trigger a rescan.
+   */
+  public function testPreviewIgnoresConfigChangesWhenCached() {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save();
+
+    file_put_contents("$public/foo.txt", 'f');
+    $this->config('file_adoption.settings')->set('ignore_patterns', '')->save();
+
+    $form_state = new FormState();
+    $form_state->setTriggeringElement(['#name' => 'quick_scan']);
+    $form = [];
+    $form_object = new FileAdoptionForm(
+      $this->container->get('file_adoption.file_scanner'),
+      $this->container->get('file_system'),
+      $this->container->get('state')
+    );
+    $form_object->submitForm($form, $form_state);
+
+    // Change ignore patterns to something that would exclude foo.txt.
+    $this->config('file_adoption.settings')->set('ignore_patterns', '*.txt')->save();
+
+    $controller = new PreviewController(
+      $this->container->get('file_adoption.file_scanner'),
+      $this->container->get('file_system'),
+      $this->container->get('state')
+    );
+    $data = json_decode($controller->preview()->getContent(), TRUE);
+
+    // Should still report the original file count of 1.
+    $this->assertEquals(1, $data['count']);
+  }
+
+}


### PR DESCRIPTION
## Summary
- reuse cached dir counts in PreviewController when available
- store directory counts during quick scans and batch scans
- inject state service into PreviewController
- adjust existing tests for new constructor
- add kernel tests for preview caching behavior

## Testing
- `phpunit --configuration phpunit.xml.dist` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d96cf390c8331ac303b72dd304761