### PR TITLE
Add folder depth configuration

### DIFF
--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -12,3 +12,4 @@ ignore_patterns: |
   webform/*
 enable_adoption: false
 items_per_run: 100
+folder_depth: 2

--- a/config/schema/file_adoption.schema.yml
+++ b/config/schema/file_adoption.schema.yml
@@ -11,3 +11,7 @@ file_adoption.settings:
     items_per_run:
       type: integer
       label: 'Items processed per cron run'
+    folder_depth:
+      type: integer
+      label: 'Folder depth'
+      description: 'Maximum directory depth to scan. 0 for unlimited.'

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -111,6 +111,18 @@ class FileAdoptionForm extends ConfigFormBase {
       '#max' => 5000,
     ];
 
+    $folder_depth = $config->get('folder_depth');
+    if ($folder_depth === NULL || $folder_depth < 0) {
+      $folder_depth = 2;
+    }
+    $form['folder_depth'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Folder depth'),
+      '#default_value' => $folder_depth,
+      '#min' => 0,
+      '#description' => $this->t('Maximum subdirectory depth to scan. Use 0 for unlimited depth.'),
+    ];
+
 
     $preview_ready = $form_state->get('scan_results') || $this->state->get('file_adoption.scan_results');
 
@@ -215,10 +227,15 @@ class FileAdoptionForm extends ConfigFormBase {
     elseif ($items_per_run > 5000) {
       $items_per_run = 5000;
     }
+    $folder_depth = (int) $form_state->getValue('folder_depth');
+    if ($folder_depth < 0) {
+      $folder_depth = 0;
+    }
     $this->config('file_adoption.settings')
       ->set('ignore_patterns', $form_state->getValue('ignore_patterns'))
       ->set('enable_adoption', $form_state->getValue('enable_adoption'))
       ->set('items_per_run', $items_per_run)
+      ->set('folder_depth', $folder_depth)
       ->save();
 
     $trigger = $form_state->getTriggeringElement()['#name'] ?? '';


### PR DESCRIPTION
## Summary
- add default `folder_depth` setting
- extend config schema with `folder_depth` field
- add folder depth field to form with validation
- persist folder depth on submit

## Testing
- `bash setup.sh` *(fails: composer not found)*
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685fc6a76aac833181c4ccd73470409d