### PR TITLE
Implement async directory preview endpoints

### DIFF
--- a/file_adoption.routing.yml
+++ b/file_adoption.routing.yml
@@ -13,3 +13,30 @@ file_adoption.preview_ajax:
     _permission: 'administer site configuration'
   options:
     _format: 'json'
+
+file_adoption.dirs_ajax:
+  path: '/file-adoption/dirs'
+  defaults:
+    _controller: '\Drupal\file_adoption\Controller\PreviewController::dirs'
+  requirements:
+    _permission: 'administer site configuration'
+  options:
+    _format: 'json'
+
+file_adoption.examples_ajax:
+  path: '/file-adoption/examples'
+  defaults:
+    _controller: '\Drupal\file_adoption\Controller\PreviewController::examples'
+  requirements:
+    _permission: 'administer site configuration'
+  options:
+    _format: 'json'
+
+file_adoption.counts_ajax:
+  path: '/file-adoption/counts'
+  defaults:
+    _controller: '\Drupal\file_adoption\Controller\PreviewController::counts'
+  requirements:
+    _permission: 'administer site configuration'
+  options:
+    _format: 'json'

--- a/js/preview.js
+++ b/js/preview.js
@@ -4,11 +4,13 @@
       if (context !== document) {
         return;
       }
-      const url = drupalSettings.file_adoption.preview_url;
+      const dirsUrl = drupalSettings.file_adoption.dirs_url;
+      const examplesUrl = drupalSettings.file_adoption.examples_url;
+      const countsUrl = drupalSettings.file_adoption.counts_url;
       const wrapper = document.getElementById('file-adoption-preview');
       const details = document.getElementById('file-adoption-preview-wrapper');
       const results = document.getElementById('file-adoption-results');
-      if (!url || !wrapper) {
+      if (!dirsUrl || !wrapper) {
         return;
       }
 
@@ -37,18 +39,60 @@
         }
       }
 
-      function loadPreview() {
+      const data = { dirs: [], examples: {}, counts: {} };
+      let step = 'dirs';
+
+      function render() {
+        const dirs = data.dirs;
+        const examples = data.examples;
+        const counts = data.counts;
+        let html = '<ul>';
+        if (dirs.length) {
+          const rootExample = examples[''] ? ' (e.g., ' + Drupal.checkPlain(examples['']) + ')' : '';
+          const rootCount = typeof counts[''] !== 'undefined' ? ' (' + counts[''] + ')' : '';
+          html += '<li>' + Drupal.checkPlain('public://') + rootExample + rootCount + '</li>';
+          dirs.forEach(function (dir) {
+            let label = dir + '/';
+            if (examples[dir]) {
+              label += ' (e.g., ' + Drupal.checkPlain(examples[dir]) + ')';
+            }
+            if (typeof counts[dir] !== 'undefined' && counts[dir] > 0) {
+              label += ' (' + counts[dir] + ')';
+            }
+            html += '<li>' + Drupal.checkPlain(label) + '</li>';
+          });
+        }
+        html += '</ul>';
+        wrapper.innerHTML = '<div>' + html + '</div>';
+        if (details && typeof counts[''] !== 'undefined') {
+          const summary = details.querySelector('summary');
+          if (summary) {
+            summary.textContent = drupalSettings.file_adoption.preview_title + ' (' + counts[''] + ')';
+          }
+        }
+      }
+
+      function loadStep() {
+        const url = step === 'dirs' ? dirsUrl : (step === 'examples' ? examplesUrl : countsUrl);
         fetch(url)
           .then((response) => response.json())
-          .then((data) => {
-            if (data.markup) {
-              wrapper.innerHTML = data.markup;
-              if (details && typeof data.count !== 'undefined') {
-                const summary = details.querySelector('summary');
-                if (summary) {
-                  summary.textContent = drupalSettings.file_adoption.preview_title + ' (' + data.count + ')';
-                }
-              }
+          .then((resp) => {
+            if (step === 'dirs' && Array.isArray(resp.dirs)) {
+              data.dirs = resp.dirs;
+              step = 'examples';
+              failureCount = 0;
+              render();
+            }
+            else if (step === 'examples' && resp.examples) {
+              data.examples = resp.examples;
+              step = 'counts';
+              failureCount = 0;
+              render();
+            }
+            else if (step === 'counts' && resp.counts) {
+              data.counts = resp.counts;
+              failureCount = 0;
+              render();
               clearInterval(intervalId);
               showResults();
             }
@@ -59,8 +103,8 @@
           .catch((err) => handleFailure(err));
       }
 
-      const intervalId = setInterval(loadPreview, 3000);
-      loadPreview();
+      const intervalId = setInterval(loadStep, 3000);
+      loadStep();
     }
   };
 })(Drupal, drupalSettings);

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -138,6 +138,9 @@ class FileAdoptionForm extends ConfigFormBase {
       ];
       $form['#attached']['library'][] = 'file_adoption/preview';
       $form['#attached']['drupalSettings']['file_adoption']['preview_url'] = Url::fromRoute('file_adoption.preview_ajax')->toString();
+      $form['#attached']['drupalSettings']['file_adoption']['dirs_url'] = Url::fromRoute('file_adoption.dirs_ajax')->toString();
+      $form['#attached']['drupalSettings']['file_adoption']['examples_url'] = Url::fromRoute('file_adoption.examples_ajax')->toString();
+      $form['#attached']['drupalSettings']['file_adoption']['counts_url'] = Url::fromRoute('file_adoption.counts_ajax')->toString();
       $form['#attached']['drupalSettings']['file_adoption']['preview_title'] = $this->t('Public Directory Contents Preview');
     }
     else {


### PR DESCRIPTION
## Summary
- add new routes for directory preview endpoints
- expose preview endpoints in `FileAdoptionForm`
- add helper methods and new endpoints in `PreviewController`
- update JS to poll the new endpoints sequentially

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_685fcc7098e48331b8d107ac20a941ce