### PR TITLE
Add cron task locking and example cache

### DIFF
--- a/file_adoption.install
+++ b/file_adoption.install
@@ -46,4 +46,6 @@ function file_adoption_uninstall() {
   $state->delete('file_adoption.scan_results');
   $state->delete('file_adoption.scan_progress');
   $state->delete('file_adoption.cron_offset');
+  $state->delete('file_adoption.dir_inventory');
+  $state->delete('file_adoption.examples_cache');
 }

--- a/file_adoption.module
+++ b/file_adoption.module
@@ -12,33 +12,61 @@ function file_adoption_cron() {
   $config = \Drupal::config('file_adoption.settings');
   $state = \Drupal::state();
 
-  // Resume any pending scan batches from the configuration form.
-  if ($state->get('file_adoption.scan_progress')) {
-    $context = [];
-    file_adoption_scan_batch_step($context);
+  // Prevent overlapping cron runs.
+  $lock = $state->get('file_adoption.cron_lock');
+  if ($lock && (time() - $lock) < 3600) {
+    return;
   }
+  $state->set('file_adoption.cron_lock', time());
 
-  $limit = (int) $config->get('items_per_run');
-  if ($limit > 5000) {
-    $limit = 5000;
+  try {
+    // Resume any pending scan batches from the configuration form.
+    if ($state->get('file_adoption.scan_progress')) {
+      $context = [];
+      file_adoption_scan_batch_step($context);
+    }
+
+    /** @var \Drupal\file_adoption\FileScanner $scanner */
+    $scanner = \Drupal::service('file_adoption.file_scanner');
+
+    // Refresh directory inventory when requested.
+    if ($state->get('file_adoption.inventory_pending')) {
+      $depth = (int) $config->get('folder_depth');
+      $scanner->getDirectoryInventory($depth, TRUE);
+      $state->delete('file_adoption.inventory_pending');
+    }
+
+    // Discover example files when requested.
+    if ($state->get('file_adoption.examples_pending')) {
+      $depth = (int) $config->get('folder_depth');
+      $dirs = $scanner->getDirectoryInventory($depth);
+      array_unshift($dirs, '');
+      $scanner->cacheFolderExamples($dirs);
+      $state->delete('file_adoption.examples_pending');
+    }
+
+    $limit = (int) $config->get('items_per_run');
+    if ($limit > 5000) {
+      $limit = 5000;
+    }
+
+    // Resume incremental cron scanning using the stored offset.
+    $resume = $state->get('file_adoption.cron_offset') ?: '';
+    $chunk = $scanner->scanChunk($resume, $limit, 10);
+
+    if ($config->get('enable_adoption') && !empty($chunk['to_manage'])) {
+      $scanner->adoptFiles($chunk['to_manage']);
+    }
+
+    if ($chunk['resume'] === '') {
+      $state->delete('file_adoption.cron_offset');
+    }
+    else {
+      $state->set('file_adoption.cron_offset', $chunk['resume']);
+    }
   }
-
-  /** @var \Drupal\file_adoption\FileScanner $scanner */
-  $scanner = \Drupal::service('file_adoption.file_scanner');
-
-  // Resume incremental cron scanning using the stored offset.
-  $resume = $state->get('file_adoption.cron_offset') ?: '';
-  $chunk = $scanner->scanChunk($resume, $limit, 10);
-
-  if ($config->get('enable_adoption') && !empty($chunk['to_manage'])) {
-    $scanner->adoptFiles($chunk['to_manage']);
-  }
-
-  if ($chunk['resume'] === '') {
-    $state->delete('file_adoption.cron_offset');
-  }
-  else {
-    $state->set('file_adoption.cron_offset', $chunk['resume']);
+  finally {
+    $state->delete('file_adoption.cron_lock');
   }
 }
 

--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -26,6 +26,11 @@ class FileScanner {
     public const INVENTORY_KEY = 'file_adoption.dir_inventory';
 
     /**
+     * State key for storing example file data.
+     */
+    public const EXAMPLES_KEY = 'file_adoption.examples_cache';
+
+    /**
      * The file system service.
      *
      * @var \Drupal\Core\File\FileSystemInterface
@@ -356,6 +361,24 @@ class FileScanner {
         }
 
         return ['examples' => $examples, 'counts' => $counts];
+    }
+
+    /**
+     * Collects example files for directories and caches them.
+     *
+     * @param array $directories
+     *   Directories relative to public://.
+     *
+     * @return array
+     *   Example file names keyed by directory path.
+     */
+    public function cacheFolderExamples(array $directories): array {
+        $data = $this->collectFolderData($directories);
+        $this->state->set(self::EXAMPLES_KEY, [
+            'examples' => $data['examples'],
+            'timestamp' => time(),
+        ]);
+        return $data['examples'];
     }
 
     /**

--- a/tests/src/Kernel/CronTasksTest.php
+++ b/tests/src/Kernel/CronTasksTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\Tests\file_adoption\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\file_adoption\FileScanner;
+
+/**
+ * Tests additional cron tasks and locking.
+ *
+ * @group file_adoption
+ */
+class CronTasksTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'file', 'file_adoption'];
+
+  /**
+   * Ensures inventory and example discovery flags are processed.
+   */
+  public function testCronProcessesPendingTasks(): void {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save();
+
+    mkdir("$public/a", 0777, true);
+    file_put_contents("$public/a/example.txt", 'x');
+
+    $state = $this->container->get('state');
+    $state->set('file_adoption.inventory_pending', true);
+    $state->set('file_adoption.examples_pending', true);
+
+    file_adoption_cron();
+
+    $inventory = $state->get('file_adoption.dir_inventory')['dirs'] ?? [];
+    $examples = $state->get('file_adoption.examples_cache')['examples'] ?? [];
+
+    $this->assertEquals(['a'], $inventory);
+    $this->assertArrayHasKey('a', $examples);
+    $this->assertFalse($state->get('file_adoption.inventory_pending'));
+    $this->assertFalse($state->get('file_adoption.examples_pending'));
+  }
+
+  /**
+   * Ensures an existing lock prevents work from running.
+   */
+  public function testCronLockPreventsOverlap(): void {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save();
+
+    file_put_contents("$public/one.txt", '1');
+
+    $state = $this->container->get('state');
+    $state->set('file_adoption.cron_lock', time());
+
+    file_adoption_cron();
+
+    /** @var FileScanner $scanner */
+    $scanner = $this->container->get('file_adoption.file_scanner');
+    $result = $scanner->scanAndProcess(false);
+    $this->assertEquals(1, $result['orphans']);
+  }
+
+}
+


### PR DESCRIPTION
## Summary
- add cron locking and ability to run directory/example tasks
- cache folder examples in FileScanner
- clean additional state on uninstall
- cover cron tasks with new kernel tests

## Testing
- `phpunit -c phpunit.xml.dist` *(fails: require vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_685fce16c6ec8331ae98c092c7268e08