### PR TITLE
Implement depth check in directory inventory

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -517,6 +517,11 @@ class FileScanner {
                     continue;
                 }
 
+                $current_depth = substr_count($relative, '/') + 1;
+                if ($depth > 0 && $current_depth > $depth) {
+                    continue;
+                }
+
                 if (!in_array($relative, $dirs, TRUE)) {
                     $dirs[] = $relative;
                 }

--- a/tests/src/Kernel/FileScannerTest.php
+++ b/tests/src/Kernel/FileScannerTest.php
@@ -235,6 +235,7 @@ class FileScannerTest extends KernelTestBase {
     $depth2 = $scanner->inventoryDirectories(2);
     sort($depth2);
     $this->assertEquals(['a', 'a/b', 'd'], $depth2);
+    $this->assertNotContains('a/b/c', $depth2);
   }
 
   /**


### PR DESCRIPTION
## Summary
- enforce explicit depth checks in `inventoryDirectories()` to avoid overly deep results
- tighten kernel test for directory depth

## Testing
- `phpunit -c phpunit.xml.dist tests/src/Kernel/FileScannerTest.php` *(fails: missing `/workspace/file_adoption/vendor/autoload.php`)*

------
https://chatgpt.com/codex/tasks/task_e_685fddf93b9483319fcae66901c21a95