### PR TITLE
Modify JS refresh loop

### DIFF
--- a/js/preview.js
+++ b/js/preview.js
@@ -99,6 +99,9 @@
       }
 
       function loadStep() {
+        if (step === 'done') {
+          return;
+        }
         const url = step === 'dirs' ? dirsUrl : (step === 'examples' ? examplesUrl : countsUrl);
         fetch(url)
           .then((response) => response.json())
@@ -119,8 +122,7 @@
               data.counts = resp.counts;
               failureCount = 0;
               render();
-              clearInterval(intervalId);
-              showResults();
+              step = 'done';
             }
             else {
               handleFailure('Invalid response');
@@ -129,8 +131,26 @@
           .catch((err) => handleFailure(err));
       }
 
-      const intervalId = setInterval(loadStep, 3000);
-      loadStep();
+      wrapper.textContent = Drupal.t('Scanning in progress…');
+
+      function sectionsPopulated() {
+        const previewReady = wrapper.querySelector('li');
+        const resultsReady = results && results.querySelector('li');
+        return previewReady && resultsReady;
+      }
+
+      function refresh() {
+        if (!sectionsPopulated()) {
+          loadStep();
+          wrapper.textContent = Drupal.t('Scanning in progress…');
+        }
+        else {
+          clearInterval(intervalId);
+          showResults();
+        }
+      }
+
+      const intervalId = setInterval(refresh, 2000);
     }
   };
 })(Drupal, drupalSettings);


### PR DESCRIPTION
## Summary
- tweak preview refresh logic to wait for populated sections
- refresh every 2 seconds
- show scanning message while waiting

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: `bash: vendor/bin/phpunit: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_685fe6b956248331ad0190cbebd4b764