### PR TITLE
Show number of files displayed in adopt list

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -190,10 +190,14 @@ class FileAdoptionForm extends ConfigFormBase {
     if (!empty($scan_results)) {
       $limit = (int) $config->get('items_per_run');
       $managed_list = array_map([Html::class, 'escape'], $scan_results['to_manage']);
+      $shown = min($limit, count($managed_list));
 
       $form['results_manage'] = [
         '#type' => 'details',
-        '#title' => $this->t('Add to Managed Files (@count)', ['@count' => count($managed_list)]),
+        '#title' => $this->t('Add to Managed Files (@shown of @total)', [
+          '@shown' => $shown,
+          '@total' => count($managed_list),
+        ]),
         '#open' => TRUE,
         '#attributes' => ['id' => 'file-adoption-results'],
       ];

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -93,6 +93,7 @@ class FileAdoptionFormTest extends KernelTestBase {
     preg_match_all('/<li>/', $markup, $matches);
     $this->assertCount(2, $matches[0]);
     $this->assertStringNotContainsString('three.txt', $markup);
+    $this->assertStringContainsString('2 of 3', (string) $form['results_manage']['#title']);
   }
 
   /**


### PR DESCRIPTION
## Summary
- display how many files are shown in the adoption list
- update test to check title contains this count

## Testing
- `php -l src/Form/FileAdoptionForm.php`
- `php -l tests/src/Kernel/FileAdoptionFormTest.php`
- `vendor/bin/phpunit --configuration phpunit.xml.dist tests/src/Kernel/FileAdoptionFormTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685ff500472c8331b0cde56cfebda7cd