### PR TITLE
Add devcontainer for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "Drupal Module Dev",
+  "image": "mcr.microsoft.com/devcontainers/php:0-8.2",
+  "postCreateCommand": "composer install",
+  "forwardPorts": [8888],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "felixfbecker.php-debug",
+        "bmewburn.vscode-intelephense-client"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a devcontainer.json to support GitHub Codespaces

## Testing
- `composer install --no-interaction` *(fails: composer not found)*
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_6860007447608331add6583b25a21c4c