### PR TITLE
Configure dev container setup script

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,9 @@
 {
   "name": "Drupal Module Dev",
   "image": "mcr.microsoft.com/devcontainers/php:0-8.2",
-  "postCreateCommand": "composer install",
-  "forwardPorts": [8888],
+  "postCreateCommand": "./setup.sh",
+  "forwardPorts": [8000],
+  "remoteUser": "vscode",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,19 @@
   ],
   "repositories": [
     {
+      "type": "composer",
+      "url": "https://packages.drupal.org/8"
+    },
+    {
       "type": "vcs",
       "url": "https://github.com/dbrabon/file_adoption"
     }
   ],
   "require": {
-    "php": "^8.2"
+    "php": "^8.2",
+    "drupal/core": "^10 || ^11"
   },
   "require-dev": {
-    "drupal/core": "^10 || ^11",
     "phpunit/phpunit": "^10"
   }
 }

--- a/setup.sh
+++ b/setup.sh
@@ -1,2 +1,7 @@
 #!/bin/bash
-composer install --no-interaction
+
+# install composer deps
+composer install
+
+# set correct permissions if needed
+chmod -R 755 web/sites/default/files


### PR DESCRIPTION
## Summary
- update composer.json with Drupal repo and core requirement
- create a `setup.sh` script for devcontainer
- configure devcontainer to run setup and expose port 8000

## Testing
- `./setup.sh` *(fails: composer not found)*
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686001c011e88331b610498889050140