### PR TITLE
Remove counts/examples from preview

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -139,8 +139,6 @@ class FileAdoptionForm extends ConfigFormBase {
       $form['#attached']['library'][] = 'file_adoption/preview';
       $form['#attached']['drupalSettings']['file_adoption']['preview_url'] = Url::fromRoute('file_adoption.preview_ajax')->toString();
       $form['#attached']['drupalSettings']['file_adoption']['dirs_url'] = Url::fromRoute('file_adoption.dirs_ajax')->toString();
-      $form['#attached']['drupalSettings']['file_adoption']['examples_url'] = Url::fromRoute('file_adoption.examples_ajax')->toString();
-      $form['#attached']['drupalSettings']['file_adoption']['counts_url'] = Url::fromRoute('file_adoption.counts_ajax')->toString();
       $form['#attached']['drupalSettings']['file_adoption']['preview_title'] = $this->t('Public Directory Contents Preview');
       $form['#attached']['drupalSettings']['file_adoption']['ignore_patterns'] =
         $this->fileScanner->getIgnorePatterns();


### PR DESCRIPTION
## Summary
- prune preview `drupalSettings` to stop sending counts/examples URLs
- simplify preview JavaScript to only request directory names

## Testing
- `bash setup.sh` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68600eaec6cc8331b6eed1f43b183798