### PR TITLE
Fix results_manage title

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -194,10 +194,7 @@ class FileAdoptionForm extends ConfigFormBase {
 
       $form['results_manage'] = [
         '#type' => 'details',
-        '#title' => $this->t('Add to Managed Files (@shown of @total)', [
-          '@shown' => $shown,
-          '@total' => count($managed_list),
-        ]),
+        '#title' => $this->t('Add to Managed Files'),
         '#open' => TRUE,
         '#attributes' => ['id' => 'file-adoption-results'],
       ];


### PR DESCRIPTION
## Summary
- simplify the title for the managed files results section

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686016cdd0d08331b26261ec8804dcd1