### PR TITLE
Add ignored file path preview

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -226,7 +226,7 @@ class FileScanner {
      * @return \RecursiveIteratorIterator
      *   The configured iterator.
      */
-    private function getIterator(string $base, array &$visited, bool $child_first = TRUE): \RecursiveIteratorIterator {
+    public function getIterator(string $base, array &$visited, bool $child_first = TRUE): \RecursiveIteratorIterator {
         $dirIterator = new \RecursiveDirectoryIterator(
             $base,
             \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS


### PR DESCRIPTION
## Summary
- expose `FileScanner::getIterator()` publicly
- traverse entire public file tree to preview ignored files
- list ignored nested files in preview tests

## Testing
- `phpunit -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68601b720ce88331ab9af63bd5c0edf3