### PR TITLE
Add pending file count endpoint

### DIFF
--- a/file_adoption.libraries.yml
+++ b/file_adoption.libraries.yml
@@ -3,3 +3,4 @@ preview:
     js/preview.js: {}
   dependencies:
     - core/drupal
+    - core/drupalSettings

--- a/file_adoption.routing.yml
+++ b/file_adoption.routing.yml
@@ -40,3 +40,12 @@ file_adoption.counts_ajax:
     _permission: 'administer site configuration'
   options:
     _format: 'json'
+
+file_adoption.pending_count:
+  path: '/file-adoption/pending-count'
+  defaults:
+    _controller: '\Drupal\file_adoption\Controller\PreviewController::pendingCount'
+  requirements:
+    _permission: 'administer site configuration'
+  options:
+    _format: 'json'

--- a/js/preview.js
+++ b/js/preview.js
@@ -5,6 +5,7 @@
         return;
       }
       const dirsUrl = drupalSettings.file_adoption.dirs_url;
+      const totalUrl = drupalSettings.file_adoption.total_url;
       const patterns = drupalSettings.file_adoption.ignore_patterns || [];
 
       const regexes = patterns.map(function (pattern) {
@@ -19,6 +20,7 @@
       const wrapper = document.getElementById('file-adoption-preview');
       const details = document.getElementById('file-adoption-preview-wrapper');
       const results = document.getElementById('file-adoption-results');
+      const totalPlaceholder = document.getElementById('file-adoption-total-count');
       if (!dirsUrl || !wrapper) {
         return;
       }
@@ -34,6 +36,20 @@
         if (results) {
           results.style.display = '';
         }
+      }
+
+      function updateTotal() {
+        if (!totalUrl || !totalPlaceholder) {
+          return;
+        }
+        fetch(totalUrl)
+          .then((response) => response.json())
+          .then((resp) => {
+            if (typeof resp.count !== 'undefined') {
+              totalPlaceholder.textContent = resp.count;
+            }
+          })
+          .catch(() => {});
       }
 
       function handleFailure(error) {
@@ -117,6 +133,7 @@
         else {
           clearInterval(intervalId);
           showResults();
+          updateTotal();
         }
       }
 

--- a/src/Controller/PreviewController.php
+++ b/src/Controller/PreviewController.php
@@ -104,6 +104,15 @@ class PreviewController extends ControllerBase {
   }
 
   /**
+   * Returns the number of orphaned files from the last scan.
+   */
+  public function pendingCount(): JsonResponse {
+    $results = $this->state->get('file_adoption.scan_results') ?? [];
+    $count = (int) ($results['orphans'] ?? 0);
+    return new JsonResponse(['count' => $count]);
+  }
+
+  /**
    * Provides preview markup as JSON.
    */
   public function preview(): JsonResponse {

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -140,6 +140,7 @@ class FileAdoptionForm extends ConfigFormBase {
       $form['#attached']['library'][] = 'file_adoption/preview';
       $form['#attached']['drupalSettings']['file_adoption']['preview_url'] = Url::fromRoute('file_adoption.preview_ajax')->toString();
       $form['#attached']['drupalSettings']['file_adoption']['dirs_url'] = Url::fromRoute('file_adoption.dirs_ajax')->toString();
+      $form['#attached']['drupalSettings']['file_adoption']['total_url'] = Url::fromRoute('file_adoption.pending_count')->toString();
       $form['#attached']['drupalSettings']['file_adoption']['preview_title'] = $this->t('Public Directory Contents Preview');
       $form['#attached']['drupalSettings']['file_adoption']['ignore_patterns'] =
         $this->fileScanner->getIgnorePatterns();
@@ -214,6 +215,10 @@ class FileAdoptionForm extends ConfigFormBase {
           '#value' => Json::encode($display_uris),
         ];
       }
+
+      $form['results_total'] = [
+        '#markup' => '<div id="file-adoption-total-count"></div>',
+      ];
 
 
       $form['actions']['adopt'] = [


### PR DESCRIPTION
## Summary
- expose pending orphan count via new route
- show count below managed list
- fetch count asynchronously from UI
- include drupalSettings dependency for JS

## Testing
- `php -l src/Controller/PreviewController.php`
- `php -l src/Form/FileAdoptionForm.php`
- `phpunit -c phpunit.xml.dist tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860221eac608331ab74c2e30cdb1993