### PR TITLE
Skip directory counts during cron

### DIFF
--- a/file_adoption.module
+++ b/file_adoption.module
@@ -22,7 +22,7 @@ function file_adoption_cron() {
   try {
     // Resume any pending scan batches from the configuration form.
     if ($state->get('file_adoption.scan_progress')) {
-      $context = [];
+      $context = ['cron' => TRUE];
       file_adoption_scan_batch_step($context);
     }
 
@@ -30,20 +30,20 @@ function file_adoption_cron() {
     $scanner = \Drupal::service('file_adoption.file_scanner');
 
     // Refresh directory inventory when requested.
-    if ($state->get('file_adoption.inventory_pending')) {
-      $depth = (int) $config->get('folder_depth');
-      $scanner->getDirectoryInventory($depth, TRUE);
-      $state->delete('file_adoption.inventory_pending');
-    }
+    // if ($state->get('file_adoption.inventory_pending')) {
+    //   $depth = (int) $config->get('folder_depth');
+    //   $scanner->getDirectoryInventory($depth, TRUE);
+    //   $state->delete('file_adoption.inventory_pending');
+    // }
 
     // Discover example files when requested.
-    if ($state->get('file_adoption.examples_pending')) {
-      $depth = (int) $config->get('folder_depth');
-      $dirs = $scanner->getDirectoryInventory($depth);
-      array_unshift($dirs, '');
-      $scanner->cacheFolderExamples($dirs);
-      $state->delete('file_adoption.examples_pending');
-    }
+    // if ($state->get('file_adoption.examples_pending')) {
+    //   $depth = (int) $config->get('folder_depth');
+    //   $dirs = $scanner->getDirectoryInventory($depth);
+    //   array_unshift($dirs, '');
+    //   $scanner->cacheFolderExamples($dirs);
+    //   $state->delete('file_adoption.examples_pending');
+    // }
 
     $limit = (int) $config->get('items_per_run');
     if ($limit > 5000) {
@@ -107,7 +107,9 @@ function file_adoption_scan_batch_step(array &$context) {
 
   if ($progress['resume'] === '') {
     $context['finished'] = 1;
-    $progress['result']['dir_counts'] = $scanner->countFilesByDirectory();
+    if (empty($context['cron'])) {
+      $progress['result']['dir_counts'] = $scanner->countFilesByDirectory();
+    }
     $context['results'] = $progress['result'];
     $state->set('file_adoption.scan_results', $progress['result']);
     $state->delete('file_adoption.scan_progress');

--- a/tests/src/Kernel/CronTasksTest.php
+++ b/tests/src/Kernel/CronTasksTest.php
@@ -44,10 +44,10 @@ class CronTasksTest extends KernelTestBase {
     $inventory = $state->get('file_adoption.dir_inventory')['dirs'] ?? [];
     $examples = $state->get('file_adoption.examples_cache')['examples'] ?? [];
 
-    $this->assertEquals(['a'], $inventory);
-    $this->assertArrayHasKey('a', $examples);
-    $this->assertFalse($state->get('file_adoption.inventory_pending'));
-    $this->assertFalse($state->get('file_adoption.examples_pending'));
+    $this->assertEmpty($inventory);
+    $this->assertEmpty($examples);
+    $this->assertTrue($state->get('file_adoption.inventory_pending'));
+    $this->assertTrue($state->get('file_adoption.examples_pending'));
   }
 
   /**


### PR DESCRIPTION
## Summary
- remove cron tasks for refreshing inventory and examples
- mark cron batch steps so counts aren't recalculated
- update cron task kernel test

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686024fa84108331a25b7c25e5170170