### PR TITLE
Add per-directory scan offsets with no-orphan caching

### DIFF
--- a/file_adoption.install
+++ b/file_adoption.install
@@ -48,4 +48,8 @@ function file_adoption_uninstall() {
   $state->delete('file_adoption.cron_offset');
   $state->delete('file_adoption.dir_inventory');
   $state->delete('file_adoption.examples_cache');
+  $state->delete('file_adoption.scan_offsets');
+  $state->delete('file_adoption.scan_totals');
+  $state->delete('file_adoption.orphan_dirs');
+  $state->delete('file_adoption.no_orphan_cache');
 }


### PR DESCRIPTION
## Summary
- track scan offsets, totals and directories with orphans
- update `scanChunk()` to honor offsets and persist progress
- remember directories that contain no orphans
- clean up new state keys on uninstall

## Testing
- `php -l src/FileScanner.php`
- `php -l file_adoption.install`
- `php -l file_adoption.module`
- `apt-get update`
- `apt-get install -y composer` *(install attempt)*
- `bash setup.sh` *(failed: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68603338342083318bdbe5f8b7ec27b4