### PR TITLE
Add skip cache support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ directory is processed on each execution. After the entire directory has been
 scanned the offset resets and the cycle begins again. Cron also processes any
 pending preview tasks and will resume interrupted scans automatically. Directory
 inventories used by the preview are cached for 24 hours.
+Directories that contain no orphaned files are also cached and skipped on
+subsequent scans to reduce workload. Use the **Clear Cache** button on the
+configuration form to reset these caches when needed.
 
 ## Manual Scanning
 


### PR DESCRIPTION
## Summary
- merge cached clean directories into ignore patterns
- document skip cache in README

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml.dist tests/src/Kernel/NoOrphanDirectoryCacheTest.php` *(fails: `bash: vendor/bin/phpunit: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68602d9f7424833183df00e1734af11d