### PR TITLE
Fix initialization of positions array in scanChunk

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -794,6 +794,7 @@ class FileScanner {
 
         $visited = [];
         $iterator = $this->getIterator($public_realpath, $visited);
+        $positions = [];
 
         $skipping = $resume !== '';
         try {


### PR DESCRIPTION
## Summary
- initialize `$positions` array inside `scanChunk()`

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68603f5902a48331b2cdc90cfe5a3d1e