### PR TITLE
Initialize orphan tracking array in scanChunk

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -795,6 +795,7 @@ class FileScanner {
         $visited = [];
         $iterator = $this->getIterator($public_realpath, $visited);
         $positions = [];
+        $found_orphans = [];
 
         $skipping = $resume !== '';
         try {


### PR DESCRIPTION
## Summary
- avoid undefined variable warnings
- add `$found_orphans` initialization in `FileScanner::scanChunk`

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686040878d548331ab0516842360816d