### PR TITLE
Use scanChunk for quick scans

### DIFF
--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -155,8 +155,8 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     putenv('FILE_ADOPTION_SCAN_LIMIT');
 
-    $this->assertNull($form_state->get('scan_results'));
-    $this->assertNotEmpty($this->container->get('state')->get('file_adoption.scan_progress'));
+    $this->assertNotNull($form_state->get('scan_results'));
+    $this->assertNull($this->container->get('state')->get('file_adoption.scan_progress'));
   }
 
   /**


### PR DESCRIPTION
## Summary
- refactor quick scan implementation to call `scanChunk` directly
- update quick scan timeout test for the new behavior

## Testing
- `phpunit -c phpunit.xml.dist tests/src/Kernel/FileAdoptionFormTest.php --stop-on-failure` *(fails: Failed opening required '/workspace/file_adoption/vendor/drupal/../autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68604e70f0e083318281a9a5b9c086f6