### PR TITLE
Remove obsolete test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,3 @@ To run a scan on demand:
 2. Click **Scan Now** to see a list of files that would be adopted.
 3. Review the results and click **Adopt** to create the file entities.
 
-# file_adoption
-
-## Running Tests
-
-1. Install development dependencies using Composer:
-   ```bash
-   composer install --dev
-   ```
-2. Execute PHPUnit from the module directory:
-   ```bash
-   vendor/bin/phpunit
-   ```
-
-The tests are located under the `tests/` directory and include kernel tests for the `FileScanner` service and the configuration form.


### PR DESCRIPTION
## Summary
- remove the unused "Running Tests" section from README

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68624b568db4833181f91620d50c2f1e