### PR TITLE
Add return type hints to FileScanner methods

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -81,7 +81,7 @@ class FileScanner {
      * @return string[]
      *   An array of ignore pattern strings.
      */
-    public function getIgnorePatterns() {
+    public function getIgnorePatterns(): array {
         $config = $this->configFactory->get('file_adoption.settings');
         $raw_patterns = $config->get('ignore_patterns');
         if (empty($raw_patterns)) {
@@ -127,7 +127,7 @@ class FileScanner {
      * @return array
      *   An associative array with the keys 'files', 'orphans' and 'adopted'.
      */
-    public function scanAndProcess(bool $adopt = TRUE, int $limit = 0) {
+    public function scanAndProcess(bool $adopt = TRUE, int $limit = 0): array {
         $counts = ['files' => 0, 'orphans' => 0, 'adopted' => 0];
         $patterns = $this->getIgnorePatterns();
         // Preload all managed file URIs.
@@ -200,7 +200,7 @@ class FileScanner {
      * @return array
      *   Associative array with keys 'files', 'orphans' and 'to_manage'.
      */
-    public function scanWithLists(int $limit = 500) {
+    public function scanWithLists(int $limit = 500): array {
         $results = ['files' => 0, 'orphans' => 0, 'to_manage' => []];
         $patterns = $this->getIgnorePatterns();
         // Preload managed URIs for quick checks.
@@ -321,7 +321,7 @@ class FileScanner {
      * @return int
      *   The number of newly created items.
      */
-    public function adoptFiles(array $file_uris) {
+    public function adoptFiles(array $file_uris): int {
         $this->loadManagedUris();
         $count = 0;
         foreach ($file_uris as $uri) {
@@ -342,7 +342,7 @@ class FileScanner {
      * @return bool
      *   TRUE if a new file entity was created, FALSE otherwise.
      */
-    public function adoptFile(string $uri) {
+    public function adoptFile(string $uri): bool {
 
         try {
             if (!$this->managedLoaded) {

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -44,7 +44,7 @@ class FileAdoptionForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): static {
     return new static(
       $container->get('file_adoption.file_scanner'),
       $container->get('file_system')
@@ -54,21 +54,21 @@ class FileAdoptionForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
+  public function getFormId(): string {
     return 'file_adoption_settings_form';
   }
 
   /**
    * {@inheritdoc}
    */
-  protected function getEditableConfigNames() {
+  protected function getEditableConfigNames(): array {
     return ['file_adoption.settings'];
   }
 
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state) {
+  public function buildForm(array $form, FormStateInterface $form_state): array {
     $config = $this->config('file_adoption.settings');
 
     $form['ignore_patterns'] = [
@@ -290,7 +290,7 @@ class FileAdoptionForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submitForm(array &$form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
     $items_per_run = (int) $form_state->getValue('items_per_run');
     if ($items_per_run <= 0) {
       $items_per_run = 20;


### PR DESCRIPTION
## Summary
- add return type hints on FileScanner methods
- update FileAdoptionForm methods with return type hints as well

## Testing
- `php -l src/FileScanner.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68624bc76b9083318f8c98520532530e