### PR TITLE
Handle list limit without stopping scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .idea/
+.phpunit.result.cache

--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -216,9 +216,6 @@ class FileScanner {
         );
 
         foreach ($iterator as $file_info) {
-            if ($limit > 0 && count($results['to_manage']) >= $limit) {
-                break;
-            }
             if (!$file_info->isFile()) {
                 continue;
             }


### PR DESCRIPTION
## Summary
- remove early break in `scanWithLists`
- add `.phpunit.result.cache` to `.gitignore`
- create `FileScannerTest` to ensure counts continue after limit is reached

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_68625f3f95488331aeff9fd2338b6e50