### PR TITLE
Add skip_symlinks option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The configuration form offers the following options:
   files using the configured settings.
 - **Items per cron run** – Maximum number of files processed and displayed per
   scan or cron run. Defaults to 20.
+- **Skip symbolic links** – When enabled, symlinked files are ignored during scanning.
 
 Changes are stored in `file_adoption.settings`.
 

--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -9,3 +9,4 @@ ignore_patterns: |
   styles/*
 enable_adoption: false
 items_per_run: 20
+skip_symlinks: true

--- a/config/schema/file_adoption.schema.yml
+++ b/config/schema/file_adoption.schema.yml
@@ -11,3 +11,6 @@ file_adoption.settings:
     items_per_run:
       type: integer
       label: 'Items processed per cron run'
+    skip_symlinks:
+      type: boolean
+      label: 'Skip symbolic links'

--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -130,6 +130,7 @@ class FileScanner {
     public function scanAndProcess(bool $adopt = TRUE, int $limit = 0): array {
         $counts = ['files' => 0, 'orphans' => 0, 'adopted' => 0];
         $patterns = $this->getIgnorePatterns();
+        $skip_symlinks = (bool) $this->configFactory->get('file_adoption.settings')->get('skip_symlinks');
         // Preload all managed file URIs.
         $this->loadManagedUris();
         // Only track whether the file is already managed.
@@ -148,6 +149,9 @@ class FileScanner {
                 break;
             }
             if (!$file_info->isFile()) {
+                continue;
+            }
+            if ($skip_symlinks && $file_info->isLink()) {
                 continue;
             }
 
@@ -203,6 +207,7 @@ class FileScanner {
     public function scanWithLists(int $limit = 500): array {
         $results = ['files' => 0, 'orphans' => 0, 'to_manage' => []];
         $patterns = $this->getIgnorePatterns();
+        $skip_symlinks = (bool) $this->configFactory->get('file_adoption.settings')->get('skip_symlinks');
         // Preload managed URIs for quick checks.
         $this->loadManagedUris();
         $public_realpath = $this->fileSystem->realpath('public://');
@@ -217,6 +222,9 @@ class FileScanner {
 
         foreach ($iterator as $file_info) {
             if (!$file_info->isFile()) {
+                continue;
+            }
+            if ($skip_symlinks && $file_info->isLink()) {
                 continue;
             }
 
@@ -263,6 +271,7 @@ class FileScanner {
      */
     public function countFiles(string $relative_path = ''): int {
         $patterns = $this->getIgnorePatterns();
+        $skip_symlinks = (bool) $this->configFactory->get('file_adoption.settings')->get('skip_symlinks');
         $public_realpath = $this->fileSystem->realpath('public://');
 
         if (!$public_realpath || !is_dir($public_realpath)) {
@@ -282,6 +291,9 @@ class FileScanner {
         $count = 0;
         foreach ($iterator as $file_info) {
             if (!$file_info->isFile()) {
+                continue;
+            }
+            if ($skip_symlinks && $file_info->isLink()) {
                 continue;
             }
 

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -85,6 +85,13 @@ class FileAdoptionForm extends ConfigFormBase {
       '#description' => $this->t('If checked, orphaned files will be adopted automatically during cron runs.'),
     ];
 
+    $form['skip_symlinks'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Skip symbolic links'),
+      '#default_value' => $config->get('skip_symlinks'),
+      '#description' => $this->t('Exclude symlinked files when scanning.'),
+    ];
+
     $items_per_run = $config->get('items_per_run');
     if (empty($items_per_run)) {
       $items_per_run = 20;
@@ -298,6 +305,7 @@ class FileAdoptionForm extends ConfigFormBase {
     $this->config('file_adoption.settings')
       ->set('ignore_patterns', $form_state->getValue('ignore_patterns'))
       ->set('enable_adoption', $form_state->getValue('enable_adoption'))
+      ->set('skip_symlinks', $form_state->getValue('skip_symlinks'))
       ->set('items_per_run', $items_per_run)
       ->save();
 


### PR DESCRIPTION
## Summary
- add skip_symlinks configuration and schema
- expose Skip symbolic links checkbox in FileAdoptionForm
- ignore symlinks in FileScanner when option enabled
- document new option in README

## Testing
- `phpunit -v tests/FileScannerTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862610e0158833194edecc1c79d1447