### PR TITLE
Add warning handling and error counter

### DIFF
--- a/tests/FileScannerTest.php
+++ b/tests/FileScannerTest.php
@@ -113,6 +113,7 @@ namespace Drupal\file_adoption\Tests {
             $this->assertEquals(3, $results['files']);
             $this->assertEquals(3, $results['orphans']);
             $this->assertCount(1, $results['to_manage']);
+            $this->assertEquals(0, $results['errors']);
 
             unlink($dir . '/a.txt');
             unlink($dir . '/b.txt');
@@ -135,6 +136,8 @@ namespace Drupal\file_adoption\Tests {
             $this->assertEquals(1, $batch2['results']['files']);
             $total_files = $batch1['results']['files'] + $batch2['results']['files'];
             $this->assertEquals(3, $total_files);
+            $this->assertEquals(0, $batch1['results']['errors']);
+            $this->assertEquals(0, $batch2['results']['errors']);
 
             unlink($dir . '/a.txt');
             unlink($dir . '/b.txt');
@@ -155,6 +158,7 @@ namespace Drupal\file_adoption\Tests {
             $this->assertEquals(2, $results['files']);
             $this->assertEquals(2, $results['orphans']);
             $this->assertEquals(1, $results['adopted']);
+            $this->assertEquals(1, $results['errors']);
             $this->assertCount(1, $logger->errors);
 
             unlink($dir . '/a.txt');


### PR DESCRIPTION
## Summary
- add error counter and new warning handling in FileScanner
- update unit tests for new `errors` stat

## Testing
- `phpunit --no-configuration tests/FileScannerTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68626b8bf96c83318368f1226ec69f19