### PR TITLE
Update cache lifetime default

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The configuration form offers the following options:
   scan or cron run. Defaults to 20.
 - **Skip symlinks** – Enabled by default to ignore files reached through symbolic links. Disable to include them in scans.
 - **Inventory cache lifetime** – Number of seconds to keep scan results before
-  performing a new scan. Defaults to 3600 (1 hour).
+  performing a new scan. Defaults to 86400 (24 hours).
 
 Changes are stored in `file_adoption.settings`.
 

--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -10,4 +10,4 @@ ignore_patterns: |
 enable_adoption: false
 items_per_run: 20
 follow_symlinks: false
-cache_lifetime: 3600
+cache_lifetime: 86400

--- a/file_adoption.module
+++ b/file_adoption.module
@@ -25,7 +25,7 @@ function file_adoption_cron() {
   $cache = \Drupal::cache()->get('file_adoption.inventory');
   $lifetime = (int) $config->get('cache_lifetime');
   if ($lifetime <= 0) {
-    $lifetime = 3600;
+    $lifetime = 86400;
   }
 
   if ($cache && isset($cache->data['timestamp']) && (time() - $cache->data['timestamp'] < $lifetime) && !empty($cache->data['results']['to_manage'])) {

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -94,7 +94,7 @@ class FileAdoptionForm extends ConfigFormBase {
         $cache = \Drupal::cache()->get('file_adoption.inventory');
         $lifetime = (int) $config->get('cache_lifetime');
         if ($lifetime <= 0) {
-          $lifetime = 3600;
+          $lifetime = 86400;
         }
         if ($cache && isset($cache->data['timestamp']) && (time() - $cache->data['timestamp'] < $lifetime)) {
           $form_state->set('scan_results', $cache->data['results']);
@@ -136,7 +136,7 @@ class FileAdoptionForm extends ConfigFormBase {
 
     $lifetime = (int) $config->get('cache_lifetime');
     if ($lifetime <= 0) {
-      $lifetime = 3600;
+      $lifetime = 86400;
     }
     $form['cache_lifetime'] = [
       '#type' => 'number',
@@ -356,7 +356,7 @@ class FileAdoptionForm extends ConfigFormBase {
     }
     $cache_lifetime = (int) $form_state->getValue('cache_lifetime');
     if ($cache_lifetime <= 0) {
-      $cache_lifetime = 3600;
+      $cache_lifetime = 86400;
     }
     $this->config('file_adoption.settings')
       ->set('ignore_patterns', $form_state->getValue('ignore_patterns'))
@@ -415,7 +415,7 @@ class FileAdoptionForm extends ConfigFormBase {
 
       $lifetime = (int) $this->config('file_adoption.settings')->get('cache_lifetime');
       if ($lifetime <= 0) {
-        $lifetime = 3600;
+        $lifetime = 86400;
       }
       $cache_data = [
         'results' => $results,
@@ -480,7 +480,7 @@ class FileAdoptionForm extends ConfigFormBase {
       \Drupal::messenger()->addStatus(\Drupal::translation()->translate('Scan complete: @count file(s) found.', ['@count' => $results['files']]));
       $lifetime = (int) \Drupal::config('file_adoption.settings')->get('cache_lifetime');
       if ($lifetime <= 0) {
-        $lifetime = 3600;
+        $lifetime = 86400;
       }
       $cache_data = [
         'results' => $results,


### PR DESCRIPTION
## Summary
- set `cache_lifetime` default to 86400 seconds
- document new cache lifetime value

## Testing
- `phpunit tests/FileScannerTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68628b693a24833187d5b245393a58ff