### PR TITLE
Add UriHelper and refactor pattern logic

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -5,6 +5,7 @@ namespace Drupal\file_adoption;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\File\FileSystemInterface;
+use Drupal\file_adoption\Util\UriHelper;
 use Psr\Log\LoggerInterface;
 use Drupal\file\Entity\File;
 
@@ -377,14 +378,7 @@ class FileScanner {
                 }
 
                 // Ignore based on configured patterns.
-                $ignored = FALSE;
-                foreach ($patterns as $pattern) {
-                    if ($pattern !== '' && fnmatch($pattern, $relative_path)) {
-                        $ignored = TRUE;
-                        break;
-                    }
-                }
-                if ($ignored) {
+                if (UriHelper::matchesIgnore($relative_path, $patterns)) {
                     continue;
                 }
 
@@ -404,8 +398,7 @@ class FileScanner {
                     continue;
                 }
 
-                $dir_rel = dirname($relative_path);
-                $dir_uri = $dir_rel === '.' ? 'public://' : 'public://' . $dir_rel;
+                $dir_uri = UriHelper::getParentDir($uri);
                 $dir_id = $this->ensureDirectory($dir_uri, $file_info->getMTime());
                 $this->ensureFile($uri, $mtime, $dir_id);
 
@@ -577,14 +570,7 @@ class FileScanner {
                     continue;
                 }
 
-                $ignored = FALSE;
-                foreach ($patterns as $pattern) {
-                    if ($pattern !== '' && fnmatch($pattern, $relative_path)) {
-                        $ignored = TRUE;
-                        break;
-                    }
-                }
-                if ($ignored) {
+                if (UriHelper::matchesIgnore($relative_path, $patterns)) {
                     continue;
                 }
 
@@ -601,8 +587,7 @@ class FileScanner {
                 }
 
                 if (!isset($this->managedUris[$uri])) {
-                    $dir_rel = dirname($relative_path);
-                    $dir_uri = $dir_rel === '.' ? 'public://' : 'public://' . $dir_rel;
+                    $dir_uri = UriHelper::getParentDir($uri);
                     $dir_id = $this->ensureDirectory($dir_uri, $file_info->getMTime());
                     $this->ensureFile($uri, $mtime, $dir_id);
 
@@ -758,14 +743,7 @@ class FileScanner {
                     continue;
                 }
 
-                $ignored = FALSE;
-                foreach ($patterns as $pattern) {
-                    if ($pattern !== '' && fnmatch($pattern, $relative_path)) {
-                        $ignored = TRUE;
-                        break;
-                    }
-                }
-                if ($ignored) {
+                if (UriHelper::matchesIgnore($relative_path, $patterns)) {
                     continue;
                 }
 
@@ -792,8 +770,7 @@ class FileScanner {
                 }
 
                 if (!isset($this->managedUris[$uri])) {
-                    $dir_rel = dirname($relative_path);
-                    $dir_uri = $dir_rel === '.' ? 'public://' : 'public://' . $dir_rel;
+                    $dir_uri = UriHelper::getParentDir($uri);
                     $dir_id = $this->ensureDirectory($dir_uri, $file_info->getMTime());
                     $this->ensureFile($uri, $mtime, $dir_id);
 
@@ -892,14 +869,7 @@ class FileScanner {
                     continue;
                 }
 
-                $ignored = FALSE;
-                foreach ($patterns as $pattern) {
-                    if ($pattern !== '' && fnmatch($pattern, $relative)) {
-                        $ignored = TRUE;
-                        break;
-                    }
-                }
-                if ($ignored) {
+                if (UriHelper::matchesIgnore($relative, $patterns)) {
                     continue;
                 }
 

--- a/src/Util/UriHelper.php
+++ b/src/Util/UriHelper.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\file_adoption\Util;
+
+/**
+ * Utility methods for working with file URIs.
+ */
+class UriHelper {
+
+    /**
+     * Gets the parent directory URI of the given file or directory URI.
+     */
+    public static function getParentDir(string $uri): string {
+        if (str_starts_with($uri, 'public://')) {
+            $relative = substr($uri, 9);
+            $dir = dirname($relative);
+            return $dir === '.' ? 'public://' : 'public://' . $dir;
+        }
+        $dir = dirname($uri);
+        return $dir === '.' ? '' : $dir;
+    }
+
+    /**
+     * Checks if the provided relative URI matches any ignore pattern.
+     */
+    public static function matchesIgnore(string $relative_uri, array $patterns): bool {
+        foreach ($patterns as $pattern) {
+            if ($pattern !== '' && fnmatch($pattern, $relative_uri)) {
+                return TRUE;
+            }
+        }
+        return FALSE;
+    }
+}

--- a/tests/FileScannerTest.php
+++ b/tests/FileScannerTest.php
@@ -65,6 +65,7 @@ namespace Drupal\Core\Database {
 }
 
 namespace Drupal\file_adoption {
+    require_once __DIR__ . '/../src/Util/UriHelper.php';
     require_once __DIR__ . '/../src/FileScanner.php';
 
     class TestFileScanner extends FileScanner {


### PR DESCRIPTION
## Summary
- add `UriHelper` helper class
- use `UriHelper` for ignore matching and parent dir in scanner and form
- update tests to include new helper

## Testing
- `vendor/bin/phpunit --version` *(fails: command not found)*
- `phpunit -c phpunit.xml.dist` *(fails: command not found)*
- `composer install` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68639f55ce208331bf778f5e5e1a771d