### PR TITLE
Database-driven preview and batch actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,8 @@ scan. This allows large inventories to be adopted across multiple cron runs.
 To run a scan on demand:
 
 1. Visit the File Adoption configuration page at `/admin/reports/file-adoption`.
-2. Click **Quick Scan** for a fast scan or **Batch Scan** to process files using Drupal's Batch API.
-3. Review the results and click **Adopt** to create the file entities.
-4. If results are cached and you want a fresh scan, click **Refresh inventory**.
+2. Click **Scan** to populate the tracking tables.
+3. Use **Adopt** to register unmanaged files or **Cleanup** to remove stale records.
 
 ## Performance Considerations
 
@@ -59,8 +58,6 @@ prefer running scans via cron so processing occurs in the background. Use the
 module's **Items per cron run** setting to control how many files are processed
 in each pass.
 
-The **Public Directory Contents Preview** is only built when a recent inventory
-is cached or results were loaded from a batch scan. If no cached inventory is
-available, the form skips directory scanning and displays a placeholder message
-instead.
+The **Tracked Files** preview is built from the module's database tables. Use
+the filters to view only ignored or unmanaged files.
 

--- a/file_adoption.services.yml
+++ b/file_adoption.services.yml
@@ -10,3 +10,9 @@ services:
       - '@database'
       - '@config.factory'
       - '@logger.channel.file_adoption'
+  file_adoption.inventory_manager:
+    class: 'Drupal\file_adoption\InventoryManager'
+    arguments:
+      - '@database'
+      - '@file_system'
+      - '@file_adoption.file_scanner'

--- a/src/InventoryManager.php
+++ b/src/InventoryManager.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Drupal\file_adoption;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\File\FileSystemInterface;
+
+/**
+ * Provides database-driven operations for file adoption.
+ */
+class InventoryManager {
+
+    protected Connection $database;
+    protected FileSystemInterface $fileSystem;
+    protected FileScanner $scanner;
+
+    public function __construct(Connection $database, FileSystemInterface $file_system, FileScanner $scanner) {
+        $this->database = $database;
+        $this->fileSystem = $file_system;
+        $this->scanner = $scanner;
+    }
+
+    /**
+     * Check if the injected database supports queries.
+     */
+    protected function hasDb(): bool {
+        return is_object($this->database) && method_exists($this->database, 'select');
+    }
+
+    /**
+     * Returns a list of file URIs from the tracking table.
+     */
+    public function listFiles(bool $ignored = FALSE, bool $unmanaged = FALSE, int $limit = 50): array {
+        if (!$this->hasDb()) {
+            return [];
+        }
+        try {
+            $query = $this->database->select('file_adoption_file', 'f')
+                ->fields('f', ['uri'])
+                ->orderBy('uri')
+                ->range(0, $limit);
+            if ($ignored) {
+                $query->condition('f.ignore', 1);
+            }
+            if ($unmanaged) {
+                $query->condition('f.managed', 0);
+            }
+            $result = $query->execute();
+            $items = [];
+            foreach ($result as $row) {
+                $items[] = $row->uri;
+            }
+            return $items;
+        }
+        catch (\Throwable $e) {
+            return [];
+        }
+    }
+
+    /**
+     * Counts files in the tracking table.
+     */
+    public function countFiles(bool $ignored = FALSE, bool $unmanaged = FALSE): int {
+        if (!$this->hasDb()) {
+            return 0;
+        }
+        try {
+            $query = $this->database->select('file_adoption_file', 'f');
+            if ($ignored) {
+                $query->condition('f.ignore', 1);
+            }
+            if ($unmanaged) {
+                $query->condition('f.managed', 0);
+            }
+            $query->addExpression('COUNT(*)');
+            return (int) $query->execute()->fetchField();
+        }
+        catch (\Throwable $e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Batch operation for adopting unmanaged files.
+     */
+    public static function batchAdopt(int $limit, array &$context): void {
+        /** @var self $service */
+        $service = \Drupal::service('file_adoption.inventory_manager');
+        $service->runBatchAdopt($limit, $context);
+    }
+
+    protected function runBatchAdopt(int $limit, array &$context): void {
+        if (!$this->hasDb()) {
+            $context['finished'] = 1;
+            return;
+        }
+        if (!isset($context['sandbox']['last_id'])) {
+            $context['sandbox']['last_id'] = 0;
+            $context['results']['adopted'] = 0;
+        }
+        $query = $this->database->select('file_adoption_file', 'f')
+            ->fields('f', ['id', 'uri'])
+            ->condition('f.ignore', 0)
+            ->condition('f.managed', 0)
+            ->condition('f.id', $context['sandbox']['last_id'], '>')
+            ->orderBy('f.id')
+            ->range(0, $limit);
+        $result = $query->execute();
+        $count = 0;
+        foreach ($result as $row) {
+            if ($this->scanner->adoptFile($row->uri)) {
+                $count++;
+            }
+            $context['sandbox']['last_id'] = $row->id;
+        }
+        $context['results']['adopted'] += $count;
+        if ($count < $limit) {
+            $context['finished'] = 1;
+        }
+    }
+
+    public static function adoptFinished(bool $success, array $results, array $operations): void {
+        if ($success && !empty($results['adopted'])) {
+            \Drupal::messenger()->addStatus(\Drupal::translation()->translate('@count file(s) adopted.', ['@count' => $results['adopted']]));
+        }
+    }
+
+    /**
+     * Batch operation for cleaning stale tracking data.
+     */
+    public static function batchCleanup(int $limit, array &$context): void {
+        /** @var self $service */
+        $service = \Drupal::service('file_adoption.inventory_manager');
+        $service->runBatchCleanup($limit, $context);
+    }
+
+    protected function runBatchCleanup(int $limit, array &$context): void {
+        if (!$this->hasDb()) {
+            $context['finished'] = 1;
+            return;
+        }
+        if (!isset($context['sandbox']['last_id'])) {
+            $context['sandbox']['last_id'] = 0;
+            $context['results']['removed'] = 0;
+        }
+        $query = $this->database->select('file_adoption_file', 'f')
+            ->fields('f', ['id', 'uri'])
+            ->condition('f.id', $context['sandbox']['last_id'], '>')
+            ->orderBy('f.id')
+            ->range(0, $limit);
+        $result = $query->execute();
+        $processed = 0;
+        foreach ($result as $row) {
+            $real = $this->fileSystem->realpath($row->uri);
+            if (!$real || !file_exists($real)) {
+                $this->database->delete('file_adoption_file')
+                    ->condition('id', $row->id)
+                    ->execute();
+                $context['results']['removed']++;
+            }
+            $context['sandbox']['last_id'] = $row->id;
+            $processed++;
+        }
+        if ($processed < $limit) {
+            $context['finished'] = 1;
+        }
+    }
+
+    public static function cleanupFinished(bool $success, array $results, array $operations): void {
+        if ($success && !empty($results['removed'])) {
+            \Drupal::messenger()->addStatus(\Drupal::translation()->translate('@count stale record(s) removed.', ['@count' => $results['removed']]));
+        }
+    }
+}

--- a/tests/FileAdoptionFormTest.php
+++ b/tests/FileAdoptionFormTest.php
@@ -56,10 +56,16 @@ namespace Drupal\file_adoption {
         }
     }
 
+    class DummyInventoryManager {
+        public function listFiles(bool $ignored = false, bool $unmanaged = false, int $limit = 50): array { return []; }
+        public function countFiles(bool $ignored = false, bool $unmanaged = false): int { return 0; }
+    }
+
     class FileAdoptionFormTest extends TestCase {
         public function testPreviewSkippedWithoutCache() {
             $scanner = new RecordingScanner(sys_get_temp_dir());
             $fs = new FileSystem(sys_get_temp_dir());
+            $inventory = new DummyInventoryManager();
             $tempFactory = new PrivateTempStoreFactory();
             $config = new ConfigFactory([
                 'ignore_patterns' => '',
@@ -69,7 +75,7 @@ namespace Drupal\file_adoption {
                 'cache_lifetime' => 86400,
             ]);
             \Drupal::$cache = new MemoryCache();
-            $form = new Form\FileAdoptionForm($scanner, $fs, $tempFactory);
+            $form = new Form\FileAdoptionForm($scanner, $inventory, $fs, $tempFactory);
             $form->setConfigFactory($config);
             $state = new FormState();
             $built = $form->buildForm([], $state);


### PR DESCRIPTION
## Summary
- use new `InventoryManager` service for preview queries
- filter tracked file preview by ignored or unmanaged state
- add Scan/Adopt/Cleanup batch actions
- update README for new workflow
- adjust tests for new dependencies

## Testing
- `composer install` *(fails: command not found)*
- `phpunit -c .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a1b60bb0833189015232198c15b3