### PR TITLE
Refactor cron to use database inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,15 @@ The configuration form offers the following options:
 - **Items per cron run** – Maximum number of files processed and displayed per
   scan or cron run. Defaults to 20.
 - **Skip symlinks** – Enabled by default to ignore files reached through symbolic links. Disable to include them in scans.
-- **Inventory cache lifetime** – Number of seconds to keep scan results before
-  performing a new scan. Defaults to 86400 (24 hours).
 
 Changes are stored in `file_adoption.settings`.
 
 ## Cron Integration
 
-When *Enable Adoption* is active, the module's `hook_cron()` implementation runs
-the file scanner during cron to register any discovered orphans automatically.
-If a cached inventory of scan results exists and is still within the configured
-cache lifetime, cron processes items from that list before performing a new
-scan. This allows large inventories to be adopted across multiple cron runs.
+When *Enable Adoption* is active, the module's `hook_cron()` implementation
+registers unmanaged files found in the tracking table on each run. Up to the
+configured number of items are adopted per invocation so large inventories can
+be processed gradually.
 
 ## Manual Scanning
 

--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -10,4 +10,3 @@ ignore_patterns: |
 enable_adoption: false
 items_per_run: 20
 follow_symlinks: false
-cache_lifetime: 86400

--- a/config/schema/file_adoption.schema.yml
+++ b/config/schema/file_adoption.schema.yml
@@ -14,6 +14,3 @@ file_adoption.settings:
     follow_symlinks:
       type: boolean
       label: 'Follow symbolic links'
-    cache_lifetime:
-      type: integer
-      label: 'Inventory cache lifetime'

--- a/file_adoption.module
+++ b/file_adoption.module
@@ -22,39 +22,19 @@ function file_adoption_cron() {
     $limit = 20;
   }
 
-  $cache = \Drupal::cache()->get('file_adoption.inventory');
-  $lifetime = (int) $config->get('cache_lifetime');
-  if ($lifetime <= 0) {
-    $lifetime = 86400;
-  }
-
-  if ($cache && isset($cache->data['timestamp']) && (time() - $cache->data['timestamp'] < $lifetime) && !empty($cache->data['results']['to_manage'])) {
-    $results = $cache->data['results'];
-    $uris = array_unique($results['to_manage']);
-    $to_adopt = array_slice($uris, 0, $limit);
-    foreach ($to_adopt as $uri) {
-      if ($scanner->adoptFile($uri)) {
-        $index = array_search($uri, $uris, TRUE);
-        if ($index !== FALSE) {
-          unset($uris[$index]);
-        }
-        if (!empty($results['orphans']) && $results['orphans'] > 0) {
-          $results['orphans']--;
-        }
-      }
+  try {
+    $query = \Drupal::database()->select('file_adoption_file', 'f')
+      ->fields('f', ['uri'])
+      ->condition('f.ignore', 0)
+      ->condition('f.managed', 0)
+      ->orderBy('f.id')
+      ->range(0, $limit);
+    $result = $query->execute();
+    foreach ($result as $row) {
+      $scanner->adoptFile($row->uri);
     }
-    $results['to_manage'] = array_values($uris);
-    $cache_data = [
-      'results' => $results,
-      'timestamp' => time(),
-    ];
-    \Drupal::cache()->set('file_adoption.inventory', $cache_data, time() + $lifetime);
   }
-  else {
-    // Remove outdated inventory and perform a fresh scan adopting the first chunk.
-    if ($cache) {
-      \Drupal::cache()->delete('file_adoption.inventory');
-    }
+  catch (\Throwable $e) {
     $scanner->scanAndProcess(TRUE, $limit);
   }
 }

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -127,19 +127,6 @@ class FileAdoptionForm extends ConfigFormBase {
       '#min' => 1,
     ];
 
-    $lifetime = (int) $config->get('cache_lifetime');
-    if ($lifetime <= 0) {
-      $lifetime = 86400;
-    }
-    $form['cache_lifetime'] = [
-      '#type' => 'number',
-      '#title' => $this->t('Inventory cache lifetime (seconds)'),
-      '#default_value' => $lifetime,
-      '#min' => 1,
-    ];
-
-
-
     $status_filter = $form_state->getValue('status_filter') ?? 'all';
     $form['filters'] = [
       '#type' => 'details',
@@ -225,16 +212,11 @@ class FileAdoptionForm extends ConfigFormBase {
     if ($items_per_run <= 0) {
       $items_per_run = 20;
     }
-    $cache_lifetime = (int) $form_state->getValue('cache_lifetime');
-    if ($cache_lifetime <= 0) {
-      $cache_lifetime = 86400;
-    }
     $this->config('file_adoption.settings')
       ->set('ignore_patterns', $form_state->getValue('ignore_patterns'))
       ->set('enable_adoption', $form_state->getValue('enable_adoption'))
       ->set('follow_symlinks', $form_state->getValue('follow_symlinks'))
       ->set('items_per_run', $items_per_run)
-      ->set('cache_lifetime', $cache_lifetime)
       ->save();
 
     $trigger = $form_state->getTriggeringElement()['#name'] ?? '';

--- a/tests/FileAdoptionFormTest.php
+++ b/tests/FileAdoptionFormTest.php
@@ -35,6 +35,7 @@ namespace { use Drupal\Core\Cache\MemoryCache; class Drupal { public static Memo
 
 namespace Drupal\file_adoption {
     require_once __DIR__ . '/../src/Form/FileAdoptionForm.php';
+    require_once __DIR__ . '/../src/InventoryManager.php';
     use Drupal\Core\File\FileSystem;
     use Drupal\Core\TempStore\PrivateTempStoreFactory;
     use Drupal\Core\Config\ConfigFactory;
@@ -56,7 +57,8 @@ namespace Drupal\file_adoption {
         }
     }
 
-    class DummyInventoryManager {
+    class DummyInventoryManager extends \Drupal\file_adoption\InventoryManager {
+        public function __construct() {}
         public function listFiles(bool $ignored = false, bool $unmanaged = false, int $limit = 50): array { return []; }
         public function countFiles(bool $ignored = false, bool $unmanaged = false): int { return 0; }
     }
@@ -72,7 +74,6 @@ namespace Drupal\file_adoption {
                 'enable_adoption' => false,
                 'follow_symlinks' => false,
                 'items_per_run' => 20,
-                'cache_lifetime' => 86400,
             ]);
             \Drupal::$cache = new MemoryCache();
             $form = new Form\FileAdoptionForm($scanner, $inventory, $fs, $tempFactory);


### PR DESCRIPTION
## Summary
- adopt unmanaged files during cron directly from `file_adoption_file`
- drop cache lifetime option and docs
- clean up form and config for removed cache setting
- adjust tests to match new constructor

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_6863a3a1223c833191138651a72ef839