### PR TITLE
Add directory/file cleanup batch

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -250,9 +250,9 @@ class FileAdoptionForm extends ConfigFormBase {
       $batch = [
         'title' => $this->t('Cleaning up records'),
         'operations' => [
-          ['\\Drupal\\file_adoption\\InventoryManager::batchCleanup', [$items_per_run]],
+          ['\\Drupal\\file_adoption\\InventoryManager::batchPurge', []],
         ],
-        'finished' => ['\\Drupal\\file_adoption\\InventoryManager::cleanupFinished'],
+        'finished' => ['\\Drupal\\file_adoption\\InventoryManager::purgeFinished'],
       ];
       batch_set($batch);
     }


### PR DESCRIPTION
## Summary
- add cleanupDirectories() and cleanupFiles() helpers
- add batchPurge() batch operation with status output
- trigger purge from admin form Cleanup button

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_6863a59c7a3c8331a9bc23c4d5204864