### PR TITLE
Add adoption preview section

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -155,6 +155,32 @@ class FileAdoptionForm extends ConfigFormBase {
       '#markup' => Markup::create($markup),
     ];
 
+    $unmanaged_count = $this->inventoryManager->countFiles(FALSE, TRUE);
+    $unmanaged_list = $unmanaged_count ? $this->inventoryManager->listUnmanagedById($items_per_run) : [];
+    $form['adopt_preview'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Add to Managed Files'),
+      '#open' => TRUE,
+    ];
+    $adopt_markup = '';
+    if ($unmanaged_count) {
+      $adopt_markup .= '<p>' . $this->formatPlural($unmanaged_count, '@count file ready for adoption', '@count files ready for adoption') . '</p>';
+      if ($unmanaged_list) {
+        $adopt_markup .= '<ul><li>' . implode('</li><li>', array_map([Html::class, 'escape'], $unmanaged_list)) . '</li></ul>';
+      }
+    }
+    else {
+      $adopt_markup = $this->t('No unmanaged files found.');
+    }
+    $form['adopt_preview']['markup'] = [
+      '#markup' => Markup::create($adopt_markup),
+    ];
+    $form['adopt_preview']['adopt'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Adopt now'),
+      '#name' => 'adopt',
+    ];
+
     $form['actions'] = [
       '#type' => 'actions',
     ];

--- a/src/InventoryManager.php
+++ b/src/InventoryManager.php
@@ -81,6 +81,32 @@ class InventoryManager {
     }
 
     /**
+     * Returns a list of unmanaged files ordered by id.
+     */
+    public function listUnmanagedById(int $limit): array {
+        if (!$this->hasDb()) {
+            return [];
+        }
+        try {
+            $query = $this->database->select('file_adoption_file', 'f')
+                ->fields('f', ['uri'])
+                ->condition('f.ignore', 0)
+                ->condition('f.managed', 0)
+                ->orderBy('f.id')
+                ->range(0, $limit);
+            $result = $query->execute();
+            $items = [];
+            foreach ($result as $row) {
+                $items[] = $row->uri;
+            }
+            return $items;
+        }
+        catch (\Throwable $e) {
+            return [];
+        }
+    }
+
+    /**
      * Batch operation for adopting unmanaged files.
      */
     public static function batchAdopt(int $limit, array &$context): void {


### PR DESCRIPTION
## Summary
- show preview of unmanaged files ready for adoption
- add button to adopt those files
- add InventoryManager helper method to query unmanaged files by id

## Testing
- `phpunit tests` *(fails: Class "Drupal\Core\Render\Markup" not found and missing PDO driver)*

------
https://chatgpt.com/codex/tasks/task_e_6863ccd33bdc833198c2ce3a9a2ea574