### PR TITLE
Import file_managed entries on every scan

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -323,7 +323,7 @@ class FileScanner {
      */
     public function scanAndProcess(bool $adopt = TRUE, int $limit = 0): array {
         $counts = ['files' => 0, 'orphans' => 0, 'adopted' => 0, 'errors' => 0];
-        $this->populateFromManaged();
+        $this->populateManagedFiles();
         $patterns = $this->getIgnorePatterns();
         $follow_symlinks = (bool) $this->configFactory->get('file_adoption.settings')->get('follow_symlinks');
         // Preload managed URIs.
@@ -522,19 +522,7 @@ class FileScanner {
      */
     public function scanWithLists(int $limit = 500): array {
         $results = ['files' => 0, 'orphans' => 0, 'to_manage' => [], 'errors' => 0];
-        if ($this->hasDb()) {
-            try {
-                $count = $this->database->select('file_adoption_file', 'f')
-                    ->addExpression('COUNT(*)')
-                    ->execute()
-                    ->fetchField();
-                if ($count == 0) {
-                    $this->populateManagedFiles();
-                }
-            }
-            catch (\Throwable $e) {
-            }
-        }
+        $this->populateManagedFiles();
         $patterns = $this->getIgnorePatterns();
         $follow_symlinks = (bool) $this->configFactory->get('file_adoption.settings')->get('follow_symlinks');
         // Preload managed URIs for quick checks.
@@ -708,19 +696,7 @@ class FileScanner {
     public function scanChunk(int $offset, int $limit = 100): array {
         $chunk = ['results' => ['files' => 0, 'orphans' => 0, 'to_manage' => [], 'errors' => 0], 'offset' => $offset];
 
-        if ($this->hasDb()) {
-            try {
-                $count = $this->database->select('file_adoption_file', 'f')
-                    ->addExpression('COUNT(*)')
-                    ->execute()
-                    ->fetchField();
-                if ($count == 0) {
-                    $this->populateManagedFiles();
-                }
-            }
-            catch (\Throwable $e) {
-            }
-        }
+        $this->populateManagedFiles();
         $patterns = $this->getIgnorePatterns();
         $follow_symlinks = (bool) $this->configFactory->get('file_adoption.settings')->get('follow_symlinks');
         $this->loadManagedUris();


### PR DESCRIPTION
## Summary
- ensure managed files are imported at the start of each scan
- test that managed file records persist across scans

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_6863e9baaf1c8331b340c1e617326506