### PR TITLE
Initialize adoption tables from file_managed

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Scanning and adoption rely on two tables provided by the module:
 These tables keep a persistent inventory so subsequent scans and cron runs only
 process new or changed items.
 
+When the tables are empty, a one-time initialization runs before the first scan.
+All URIs from Drupal's `file_managed` table are imported so existing managed
+files are tracked and not reported as orphans.
+
 ## Cron Integration
 
 When *Enable Adoption* is active, the module's `hook_cron()` implementation

--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -356,7 +356,7 @@ class FileScanner {
      */
     public function scanAndProcess(bool $adopt = TRUE, int $limit = 0): array {
         $counts = ['files' => 0, 'orphans' => 0, 'adopted' => 0, 'errors' => 0];
-        $this->populateManagedFiles();
+        $this->populateFromManaged();
         $patterns = $this->getIgnorePatterns();
         $follow_symlinks = (bool) $this->configFactory->get('file_adoption.settings')->get('follow_symlinks');
         // Preload managed URIs.
@@ -608,7 +608,7 @@ class FileScanner {
      */
     public function scanWithLists(int $limit = 500): array {
         $results = ['files' => 0, 'orphans' => 0, 'to_manage' => [], 'errors' => 0];
-        $this->populateManagedFiles();
+        $this->populateFromManaged();
         $patterns = $this->getIgnorePatterns();
         $follow_symlinks = (bool) $this->configFactory->get('file_adoption.settings')->get('follow_symlinks');
         // Preload managed URIs for quick checks.
@@ -835,7 +835,7 @@ class FileScanner {
     public function scanChunk(int $offset, int $limit = 100): array {
         $chunk = ['results' => ['files' => 0, 'orphans' => 0, 'to_manage' => [], 'errors' => 0], 'offset' => $offset];
 
-        $this->populateManagedFiles();
+        $this->populateFromManaged();
         $patterns = $this->getIgnorePatterns();
         $follow_symlinks = (bool) $this->configFactory->get('file_adoption.settings')->get('follow_symlinks');
         $this->loadManagedUris();


### PR DESCRIPTION
## Summary
- load managed file URIs into tracking tables once
- document the initialization step in the README

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ffc2bec88331b0dd1b37d6ddeec8