### PR TITLE
Add directory preview filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ in each pass.
 The **Tracked Files** preview lists the tracked files found during the most
 recent scan using the configured ignore patterns.
 
-The **Directory Preview** section shows directories found during the scan.
-Directories are grouped by their ignore status, with separate lists for tracked
-and ignored paths.
+The **Directory Preview** section lists directories stored in the
+`file_adoption_dir` table. A filter lets you toggle between tracked and ignored
+paths and the section header displays the total count for the selected group.
+Only a sample of directories is shown when more exist.
 

--- a/tests/FileAdoptionFormTest.php
+++ b/tests/FileAdoptionFormTest.php
@@ -138,16 +138,14 @@ namespace Drupal\file_adoption {
             $this->assertStringContainsString('foo.txt', $built['preview']['markup']['#markup']);
         }
 
-        public function testDirectoryPreviewListsDirectories() {
+        public function testDirectoryPreviewFiltersDirectories() {
             $scanner = new RecordingScanner(sys_get_temp_dir());
             $fs = new FileSystem(sys_get_temp_dir());
             $inventory = new class extends DummyInventoryManager {
-                public function listDirsGrouped(): array {
-                    return [
-                        'active' => ['public://dir1'],
-                        'ignored' => ['public://dir2']
-                    ];
+                public function listDirs(bool $ignored = false, int $limit = 50): array {
+                    return $ignored ? ['public://dir2'] : ['public://dir1'];
                 }
+                public function countDirs(bool $ignored = false): int { return 1; }
             };
             $config = new ConfigFactory([
                 'ignore_patterns' => '',
@@ -163,9 +161,15 @@ namespace Drupal\file_adoption {
             $state = new FormState();
             $built = $form->buildForm([], $state);
 
-            $markup = $built['dir_preview']['markup']['#markup'];
+            $markup = $built['dir_preview']['list']['markup']['#markup'];
             $this->assertStringContainsString('public://dir1', $markup);
+            $this->assertStringNotContainsString('public://dir2', $markup);
+
+            $state->setValue('dir_filter', 'ignored');
+            $built = $form->buildForm([], $state);
+            $markup = $built['dir_preview']['list']['markup']['#markup'];
             $this->assertStringContainsString('public://dir2', $markup);
+            $this->assertStringNotContainsString('public://dir1', $markup);
         }
     }
 }


### PR DESCRIPTION
## Summary
- query `file_adoption_dir` for ignored/unignored directories
- add filter for tracked vs ignored directories in "Directory Preview"
- show counts in the preview heading
- update tests
- document the new preview behaviour

## Testing
- `php -l src/Form/FileAdoptionForm.php`
- `phpunit tests` *(fails: `PDOException: could not find driver`)*

------
https://chatgpt.com/codex/tasks/task_e_6864016c99948331b40c0ed4e8b7de05