### PR TITLE
Implement uninstall hook

### DIFF
--- a/file_adoption.install
+++ b/file_adoption.install
@@ -118,6 +118,18 @@ function file_adoption_install() {
 }
 
 /**
+ * Implements hook_uninstall().
+ */
+function file_adoption_uninstall() {
+  $schema = \Drupal::database()->schema();
+  foreach (['file_adoption_dir', 'file_adoption_file'] as $table) {
+    if ($schema->tableExists($table)) {
+      $schema->dropTable($table);
+    }
+  }
+}
+
+/**
  * Implements hook_update_N().
  */
 function file_adoption_update_10001() {


### PR DESCRIPTION
## Summary
- add MODULE_uninstall() to drop tracking tables

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist` *(fails: no such file)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640da5a65c833191425fb680cf7a87