### PR TITLE
Conditionally import managed files

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -69,7 +69,7 @@ class FileScanner {
             // scans have already been performed. This keeps the inventory in
             // sync if new files are added to the file_managed table between
             // scans.
-            $this->database->select('file_adoption_file', 'f')
+            $count = $this->database->select('file_adoption_file', 'f')
                 ->addExpression('COUNT(*)')
                 ->execute()
                 ->fetchField();
@@ -78,7 +78,11 @@ class FileScanner {
             return;
         }
 
-        $this->populateManagedFiles();
+        // Import managed files only when no tracking records exist. This keeps
+        // the inventory synchronized while avoiding duplicate entries.
+        if ((int) $count === 0) {
+            $this->populateManagedFiles();
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- check the number of records in `file_adoption_file`
- only populate from `file_managed` when the table is empty
- document the conditional import with inline comments

## Testing
- `phpunit` *(fails: command not found)*
- `curl -sS https://getcomposer.org/installer -o composer-setup.php` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68641cfd3928833188ee3f5fe8244947