### PR TITLE
Remove redundant scan depth calls

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -474,14 +474,6 @@ class FileScanner {
             if ($max_depth > 0) {
                 $iterator->setMaxDepth($max_depth);
             }
-            $max_depth = (int) $this->configFactory->get('file_adoption.settings')->get('scan_depth');
-            if ($max_depth > 0) {
-                $iterator->setMaxDepth($max_depth);
-            }
-            $max_depth = (int) $this->configFactory->get('file_adoption.settings')->get('scan_depth');
-            if ($max_depth > 0) {
-                $iterator->setMaxDepth($max_depth);
-            }
         }
         catch (\UnexpectedValueException | \RuntimeException $e) {
             $this->logger->warning('Failed to iterate directory @dir: @message', [


### PR DESCRIPTION
## Summary
- streamline FileScanner scan_depth handling

## Testing
- `phpunit --version` *(fails: command not found)*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68641e2d744c8331adeaf68b38b69382