### PR TITLE
Add debug log path configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The configuration form offers the following options:
   links are included in scans. Disabled by default.
 - **Maximum scan depth** – Limit how many directory levels scans will traverse.
   Set to `0` for no limit.
+- **Debug log path** – Optional file path for detailed scan logs.
 
 Changes are stored in `file_adoption.settings`.
 
@@ -103,7 +104,7 @@ loading every file into memory at once.
 
 ## Troubleshooting
 
-- Set `debug_log_path` to record detailed scanning and adoption output.
+- Set `debug_log_path` (defaults to `public://file_adoption_debug.log`) to record detailed scanning and adoption output.
 - Review the generated log to follow how directories and files are processed.
 - Previews may be stale until another scan is performed.
 

--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -11,3 +11,4 @@ enable_adoption: false
 items_per_run: 20
 follow_symlinks: false
 scan_depth: 0
+debug_log_path: 'public://file_adoption_debug.log'

--- a/config/schema/file_adoption.schema.yml
+++ b/config/schema/file_adoption.schema.yml
@@ -17,3 +17,7 @@ file_adoption.settings:
     scan_depth:
       type: integer
       label: 'Maximum scan depth'
+    debug_log_path:
+      type: string
+      label: 'Debug log path'
+      description: 'File path to record detailed scan logs'

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -112,6 +112,13 @@ class FileAdoptionForm extends ConfigFormBase {
       '#description' => $this->t('Limit directory traversal to this depth. Use 0 for unlimited.'),
     ];
 
+    $form['debug_log_path'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Debug log path'),
+      '#default_value' => $config->get('debug_log_path') ?? '',
+      '#description' => $this->t('File path to record detailed scan logs.'),
+    ];
+
     $items_per_run = $config->get('items_per_run');
     if (empty($items_per_run)) {
       $items_per_run = 20;
@@ -268,6 +275,7 @@ class FileAdoptionForm extends ConfigFormBase {
       ->set('enable_adoption', $form_state->getValue('enable_adoption'))
       ->set('follow_symlinks', $form_state->getValue('follow_symlinks'))
       ->set('scan_depth', (int) $form_state->getValue('scan_depth'))
+      ->set('debug_log_path', $form_state->getValue('debug_log_path'))
       ->set('items_per_run', $items_per_run)
       ->save();
 


### PR DESCRIPTION
## Summary
- extend file_adoption settings schema for `debug_log_path`
- add `debug_log_path` default config
- expose a new text field on the form and save the value
- document debug log path option in README

## Testing
- `phpunit -q` *(fails: command not found)*
- `composer install` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_6864296fef48833185900e6850cfdae5