### PR TITLE
Change preview to use orphan table

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -332,6 +332,38 @@ class FileScanner {
     }
 
     /**
+     * Retrieves orphan file URIs from the tracking table.
+     *
+     * @param int $limit
+     *   Maximum number of URIs to return. 0 returns all.
+     *
+     * @return string[]
+     *   Array of file URIs.
+     */
+    public function fetchOrphans(int $limit = 0): array {
+        $query = $this->database->select($this->orphanTable, 'o')
+            ->fields('o', ['uri'])
+            ->orderBy('id');
+        if ($limit > 0) {
+            $query->range(0, $limit);
+        }
+        return $query->execute()->fetchCol();
+    }
+
+    /**
+     * Counts the number of orphan records currently stored.
+     *
+     * @return int
+     *   The number of orphans.
+     */
+    public function countOrphans(): int {
+        return (int) $this->database->select($this->orphanTable, 'o')
+            ->countQuery()
+            ->execute()
+            ->fetchField();
+    }
+
+    /**
      * Adopts (registers) the given files as managed file entities.
      *
      * @param string[] $file_uris

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -39,15 +39,18 @@ class FileAdoptionFormTest extends KernelTestBase {
     );
     $form_object->submitForm($form, $form_state);
 
-    $results = $form_state->get('scan_results');
-    $this->assertEquals(['public://example.txt'], $results['to_manage']);
-
     $count = $this->container->get('database')
       ->select('file_adoption_orphans')
       ->countQuery()
       ->execute()
       ->fetchField();
     $this->assertEquals(1, $count);
+
+    // Build form again to verify list output uses table data.
+    $form_state->setTriggeringElement([]);
+    $form = $form_object->buildForm([], $form_state);
+    $markup = $form['results_manage']['list']['#markup'];
+    $this->assertStringContainsString('example.txt', $markup);
   }
 
   /**
@@ -100,12 +103,17 @@ class FileAdoptionFormTest extends KernelTestBase {
     $this->config('file_adoption.settings')->set('ignore_patterns', 'thousand/testfiles/*')->save();
 
     $form_state = new FormState();
+    $form_state->setTriggeringElement(['#name' => 'scan']);
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
       $this->container->get('file_system')
     );
 
+    // Perform scan to populate orphan table.
+    $form_object->submitForm([], $form_state);
+
+    $form_state->setTriggeringElement([]);
     $form = $form_object->buildForm([], $form_state);
 
     $markup = $form['preview']['markup']['#markup'] ?? $form['preview']['list']['#markup'];
@@ -129,12 +137,16 @@ class FileAdoptionFormTest extends KernelTestBase {
     $this->config('file_adoption.settings')->set('ignore_patterns', 'ignored/*')->save();
 
     $form_state = new FormState();
+    $form_state->setTriggeringElement(['#name' => 'scan']);
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
       $this->container->get('file_system')
     );
 
+    $form_object->submitForm([], $form_state);
+
+    $form_state->setTriggeringElement([]);
     $form = $form_object->buildForm([], $form_state);
 
     $title = (string) $form['preview']['#title'];
@@ -158,12 +170,16 @@ class FileAdoptionFormTest extends KernelTestBase {
       ->save();
 
     $form_state = new FormState();
+    $form_state->setTriggeringElement(['#name' => 'scan']);
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
       $this->container->get('file_system')
     );
 
+    $form_object->submitForm([], $form_state);
+
+    $form_state->setTriggeringElement([]);
     $form = $form_object->buildForm([], $form_state);
 
     $title = (string) $form['preview']['#title'];


### PR DESCRIPTION
## Summary
- avoid scanning on form build
- store orphan table query helpers
- adapt UI form preview and adopt lists to use orphan table
- adjust kernel tests for new workflow

## Testing
- `composer install --dev` *(fails: command not found)*
- `phpunit tests` *(fails: Class "Drupal\KernelTests\KernelTestBase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_686464e8e0b48331828558e1a4c93364