### PR TITLE
Disable automatic file scanning on form load

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -100,9 +100,6 @@ class FileAdoptionForm extends ConfigFormBase {
 
     $public_path = $this->fileSystem->realpath('public://');
     $file_count = 0;
-    if ($public_path) {
-      $file_count = $this->fileScanner->countFiles();
-    }
 
     $form['preview'] = [
       '#type' => 'details',
@@ -204,10 +201,6 @@ class FileAdoptionForm extends ConfigFormBase {
             $preview[] = '<li><span style="color:gray">' . Html::escape($label) . ' (matches pattern ' . Html::escape($matched) . ')</span></li>';
           }
           else {
-            $count_dir = $this->fileScanner->countFiles($entry);
-            if ($count_dir > 0) {
-              $label .= ' (' . $count_dir . ')';
-            }
             $preview[] = '<li>' . Html::escape($label) . '</li>';
           }
         }


### PR DESCRIPTION
## Summary
- stop scanning file counts when the File Adoption form loads

## Testing
- `composer install --dev` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ea412390833194233dbb6dce218a