### PR TITLE
Add ignore_symlinks setting

### DIFF
--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -9,3 +9,4 @@ ignore_patterns: |
   styles/*
 enable_adoption: false
 items_per_run: 20
+ignore_symlinks: false

--- a/config/schema/file_adoption.schema.yml
+++ b/config/schema/file_adoption.schema.yml
@@ -11,3 +11,6 @@ file_adoption.settings:
     items_per_run:
       type: integer
       label: 'Items processed per cron run'
+    ignore_symlinks:
+      type: boolean
+      label: 'Ignore Symlinks'

--- a/file_adoption.install
+++ b/file_adoption.install
@@ -60,3 +60,14 @@ function file_adoption_update_10002() {
   }
   return t('Added file_adoption_orphans table.');
 }
+
+/**
+ * Adds the ignore_symlinks setting.
+ */
+function file_adoption_update_10003() {
+  $config = \Drupal::configFactory()->getEditable('file_adoption.settings');
+  if ($config->get('ignore_symlinks') === NULL) {
+    $config->set('ignore_symlinks', FALSE)->save();
+  }
+  return t('Added ignore_symlinks setting.');
+}

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -85,6 +85,13 @@ class FileAdoptionForm extends ConfigFormBase {
       '#description' => $this->t('If checked, orphaned files will be adopted automatically during cron runs.'),
     ];
 
+    $form['ignore_symlinks'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Ignore symlinks'),
+      '#default_value' => $config->get('ignore_symlinks'),
+      '#description' => $this->t('Skip symbolic links when scanning for orphaned files.'),
+    ];
+
     $items_per_run = $config->get('items_per_run');
     if (empty($items_per_run)) {
       $items_per_run = 20;
@@ -298,6 +305,7 @@ class FileAdoptionForm extends ConfigFormBase {
     $this->config('file_adoption.settings')
       ->set('ignore_patterns', $form_state->getValue('ignore_patterns'))
       ->set('enable_adoption', $form_state->getValue('enable_adoption'))
+      ->set('ignore_symlinks', $form_state->getValue('ignore_symlinks'))
       ->set('items_per_run', $items_per_run)
       ->save();
 


### PR DESCRIPTION
## Summary
- add `ignore_symlinks` default to config
- expose toggle in FileAdoptionForm
- update schema update hook for existing installs

## Testing
- `composer install --dev` *(fails: composer not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6864faee1fc8833194aec7ca3dbe941f