### PR TITLE
Update cron to record orphans when adoption disabled

### DIFF
--- a/file_adoption.module
+++ b/file_adoption.module
@@ -10,10 +10,14 @@
  */
 function file_adoption_cron() {
   $config = \Drupal::config('file_adoption.settings');
+  /** @var \Drupal\file_adoption\FileScanner $scanner */
+  $scanner = \Drupal::service('file_adoption.file_scanner');
+  $limit = (int) $config->get('items_per_run');
+
   if ($config->get('enable_adoption')) {
-    /** @var \Drupal\file_adoption\FileScanner $scanner */
-    $scanner = \Drupal::service('file_adoption.file_scanner');
-    $limit = (int) $config->get('items_per_run');
     $scanner->scanAndProcess(TRUE, $limit);
+  }
+  else {
+    $scanner->recordOrphans($limit);
   }
 }


### PR DESCRIPTION
## Summary
- add `recordOrphans()` in `FileScanner`
- update `file_adoption_cron()` to populate `file_adoption_orphans` when adoption is disabled

## Testing
- `php -l file_adoption.module`
- `php -l src/FileScanner.php`
- `phpunit` *(fails: Could not read `tests/phpunit.xml`)*

------
https://chatgpt.com/codex/tasks/task_e_6864ff6ebd848331ba54b19ce370bdd0