### PR TITLE
Update README about orphan handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Changes are stored in `file_adoption.settings`.
 
 When *Enable Adoption* is active, the module's `hook_cron()` implementation runs
 the file scanner during cron to register any discovered orphans automatically.
+If adoption is disabled, cron still records the orphaned files it finds in the
+`file_adoption_orphans` table so they can be reviewed later. The configuration
+form will display these saved results on load instead of running a fresh scan.
 
 ## Manual Scanning
 


### PR DESCRIPTION
## Summary
- document how cron records orphans when adoption is disabled
- note that config form shows saved scan results

## Testing
- `phpunit tests/src/Kernel/FileScannerTest.php` *(fails: Class "Drupal\KernelTests\KernelTestBase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865091554a08331a00184b0b01c1226