### PR TITLE
Add ignore symlinks config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The configuration form offers the following options:
   files using the configured settings.
 - **Items per cron run** – Maximum number of files processed and displayed per
   scan or cron run. Defaults to 20.
+- **Ignore Symlinks** – When enabled, symbolic links are skipped during scanning,
+  preventing loops or slowdowns caused by symlinks.
 
 Changes are stored in `file_adoption.settings`.
 


### PR DESCRIPTION
## Summary
- document Ignore Symlinks configuration setting in README

## Testing
- `composer install --dev` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68650914756083319c9bd426a6d07a4c