### PR TITLE
Fix for issue: scan only when triggered

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ When *Enable Adoption* is active, the module's `hook_cron()` implementation runs
 the file scanner during cron to register any discovered orphans automatically.
 If adoption is disabled, cron still records the orphaned files it finds in the
 `file_adoption_orphans` table so they can be reviewed later. The configuration
-form will display these saved results on load instead of running a fresh scan.
+form displays these saved results on load and no longer runs a scan
+automatically. Scans occur only during cron runs or when you press **Scan Now**
+on the configuration form.
 
 ## Manual Scanning
 

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -274,8 +274,9 @@ class FileAdoptionForm extends ConfigFormBase {
     $limit = (int) $config->get('items_per_run');
 
     // If the form does not already have scan results, attempt to load any
-    // records saved during cron runs. When none are found, perform a manual
-    // scan so the form always presents current information.
+    // records saved during cron runs. When none are found, do not run a scan
+    // automatically. Results will only be updated by cron or by pressing
+    // the Scan Now button.
     if (empty($scan_results)) {
       $database = \Drupal::database();
       $total = (int) $database->select('file_adoption_orphans')->countQuery()->execute()->fetchField();
@@ -293,8 +294,7 @@ class FileAdoptionForm extends ConfigFormBase {
         ];
       }
       else {
-        $scan_results = $this->fileScanner->scanWithLists($limit);
-        $form_state->set('scan_results', $scan_results);
+        $scan_results = [];
       }
     }
 


### PR DESCRIPTION
## Summary
- avoid automatic scanning when visiting the config form
- update documentation on when scans run

## Testing
- `composer install` *(fails: command not found)*
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68652e935b3c8331a1e92fa4f0d40e1c