### PR TITLE
Fix scanning logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ When *Enable Adoption* is active, the module's `hook_cron()` implementation runs
 the file scanner during cron to register any discovered orphans automatically.
 If adoption is disabled, cron still records the orphaned files it finds in the
 `file_adoption_orphans` table so they can be reviewed later.
-The report page now only reads these saved results and never performs an
-automatic scan. Scans are triggered via cron or by clicking **Scan Now** on the
-configuration page.
+The configuration page now only reads these saved results and never performs a
+scan automatically. Scans are triggered via cron or by clicking **Scan Now** on
+the configuration page.
 
 ## Manual Scanning
 

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -292,6 +292,9 @@ class FileAdoptionForm extends ConfigFormBase {
         ];
       }
       else {
+        // Ensure the form displays no orphan list when there are no saved
+        // results. A manual scan must be triggered explicitly.
+        $scan_results = [];
         $this->messenger()->addStatus($this->t('No scan results found. Click "Scan Now" or wait for cron.'));
       }
     }


### PR DESCRIPTION
## Summary
- prevent automatic scanning when no cron results exist
- clarify scanning in README

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6865478b69f483319973cf3b00fced29