### PR TITLE
Add condition to delay preview until scan

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -103,6 +103,11 @@ class FileAdoptionForm extends ConfigFormBase {
       '#min' => 1,
     ];
 
+    // Prevent preview and orphan listing logic from executing until a scan has
+    // been explicitly triggered.
+    $trigger = $form_state->getTriggeringElement()['#name'] ?? '';
+    if ($trigger === 'scan') {
+
 
 
     $public_path = $this->fileSystem->realpath('public://');
@@ -326,6 +331,8 @@ class FileAdoptionForm extends ConfigFormBase {
         '#button_type' => 'primary',
         '#name' => 'adopt',
       ];
+    }
+
     }
 
     return $form;


### PR DESCRIPTION
## Summary
- wrap preview and orphan listing logic in FileAdoptionForm so it only runs after pressing **Scan Now**

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68656d50179c8331a81a1f79736bf86a