### PR TITLE
Highlight unmanaged directories in preview

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -283,6 +283,45 @@ class FileScanner {
     }
 
     /**
+     * Filters a directory list based on unmanaged file presence.
+     *
+     * @param string[] $directories
+     *   Directory paths relative to public:// with trailing slashes. The root
+     *   directory should be represented as an empty string.
+     * @param string[] $unmanaged
+     *   List of unmanaged file URIs (public://...).
+     *
+     * @return string[]
+     *   Subset of $directories that contain unmanaged files.
+     */
+    public function filterDirectoriesWithUnmanaged(array $directories, array $unmanaged): array {
+        $map = array_fill_keys($directories, FALSE);
+        foreach ($unmanaged as $uri) {
+            $relative = str_starts_with($uri, 'public://') ? substr($uri, 9) : $uri;
+            $dir = dirname($relative);
+            if ($dir === '.') {
+                $dir = '';
+            }
+
+            while (TRUE) {
+                $key = $dir === '' ? '' : rtrim($dir, '/') . '/';
+                if (isset($map[$key])) {
+                    $map[$key] = TRUE;
+                }
+                if ($dir === '') {
+                    break;
+                }
+                $dir = dirname($dir);
+                if ($dir === '.') {
+                    $dir = '';
+                }
+            }
+        }
+
+        return array_keys(array_filter($map));
+    }
+
+    /**
      * Scans the public files directory and records orphans to the database.
      *
      * This is optimized for cron when adoption is disabled. It clears the


### PR DESCRIPTION
## Summary
- add a `filterDirectoriesWithUnmanaged()` helper to FileScanner
- highlight directories in FileAdoptionForm preview when unmanaged files are present
- test that preview highlights unmanaged directories and respects ignore patterns and symlink settings

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption/tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68661d976660833195606b5ce3dc6789