### PR TITLE
Implement batch scan functionality

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -400,6 +400,19 @@ class FileScanner {
     }
 
     /**
+     * Batch-compatible orphan recording step.
+     *
+     * This wrapper allows the Batch API to incrementally scan the public file
+     * directory while tracking progress in the provided context sandbox.
+     *
+     * @param array $context
+     *   Batch context array provided by the Batch API.
+     */
+    public function recordOrphansBatch(array &$context): void {
+        $this->scanBatchStep($context);
+    }
+
+    /**
      * Batch step for scanning files and recording orphans.
      *
      * This is designed for use with the Drupal Batch API. The first invocation

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -393,7 +393,7 @@ class FileAdoptionForm extends ConfigFormBase {
     }
     elseif ($trigger === 'batch_scan') {
       $operations = [
-        [[static::class, 'batchScanOperation'], []],
+        [[static::class, 'batchScanStep'], []],
       ];
       $batch = [
         'title' => $this->t('Batch scanning files'),
@@ -424,9 +424,9 @@ class FileAdoptionForm extends ConfigFormBase {
   /**
    * Batch operation callback for scanning.
   */
-  public static function batchScanOperation(&$context) {
+  public static function batchScanStep(&$context) {
     $scanner = \Drupal::service('file_adoption.file_scanner');
-    $scanner->scanBatchStep($context);
+    $scanner->recordOrphansBatch($context);
   }
 
   /**

--- a/tests/src/Kernel/FileAdoptionBatchTest.php
+++ b/tests/src/Kernel/FileAdoptionBatchTest.php
@@ -44,7 +44,7 @@ class FileAdoptionBatchTest extends KernelTestBase {
     // Execute the batch operations manually.
     $context = [];
     do {
-      FileAdoptionForm::batchScanOperation($context);
+      FileAdoptionForm::batchScanStep($context);
     } while (empty($context['finished']));
     FileAdoptionForm::batchScanFinished(TRUE, $context['results'], []);
 


### PR DESCRIPTION
## Summary
- add `recordOrphansBatch()` to FileScanner and expose as batch step
- call new batch step from FileAdoptionForm
- update kernel test to invoke new callback

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6866298317b88331bfb98914c10351d9