### PR TITLE
Fix merge conflict markers and batch progress

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -511,18 +511,15 @@ class FileScanner {
             }
         }
 
-<<<<<<< ours
-        $context['finished'] = $total > 0 ? min(1, $index / $total) : 1;
-=======
         $approx_total = $context['sandbox']['approx_total'] ?? $total;
         $actual_total = $context['sandbox']['actual_total'] ?? $total;
         if ($index >= $actual_total) {
             $context['finished'] = 1;
-        } else {
+        }
+        else {
             $total_for_progress = $approx_total > 0 ? $approx_total : $actual_total;
             $context['finished'] = $total_for_progress > 0 ? min(1, $index / $total_for_progress) : 1;
         }
->>>>>>> theirs
     }
 
     /**

--- a/tests/src/Kernel/FileAdoptionBatchTest.php
+++ b/tests/src/Kernel/FileAdoptionBatchTest.php
@@ -193,11 +193,6 @@ class FileAdoptionBatchTest extends KernelTestBase {
     $this->assertGreaterThanOrEqual(3, $iterations);
   }
 
-<<<<<<< ours
-<<<<<<< ours
-=======
-=======
->>>>>>> theirs
   /**
    * Ensures preview is displayed after a batch run when the query flag is set.
    */
@@ -234,9 +229,6 @@ class FileAdoptionBatchTest extends KernelTestBase {
     $this->assertStringContainsString('<strong>public://', $preview);
   }
 
-<<<<<<< ours
->>>>>>> theirs
-=======
   /**
    * Ensures initialization uses the approximate total based on file_managed.
    */
@@ -277,6 +269,4 @@ class FileAdoptionBatchTest extends KernelTestBase {
 
     $this->assertEquals(11, $context['sandbox']['approx_total']);
   }
-
->>>>>>> theirs
 }


### PR DESCRIPTION
## Summary
- remove merge conflict markers in `FileScanner.php` and `FileAdoptionBatchTest.php`
- use approximate totals for batch progress
- restore missing test methods

## Testing
- `php -v` *(fails: command not found)*
- `composer validate --no-check-all --strict` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b28e70048331baaec3429b08d695