### PR TITLE
Add symlink preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ The configuration form offers the following options:
   scan or cron run. Defaults to 20.
 - **Ignore Symlinks** – When enabled, symbolic links are skipped during scanning,
   preventing loops or slowdowns caused by symlinks.
+  Symlinks discovered during the preview are still listed in a separate section
+  under "Public Directory Contents Preview" with an `(ignored)` flag when this
+  option is enabled.
 
 Changes are stored in `file_adoption.settings`.
 


### PR DESCRIPTION
## Summary
- track all symlinks when building the preview
- display a new symlink section under Public Directory Contents Preview
- test symlink listing and ignored flag
- document symlink preview

## Testing
- `../vendor/bin/phpunit` *(fails: no such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866bbf2bcb08331909fe6160de75f51