### PR TITLE
Improve batch file scanning

### DIFF
--- a/tests/src/Kernel/FileAdoptionBatchTest.php
+++ b/tests/src/Kernel/FileAdoptionBatchTest.php
@@ -103,9 +103,19 @@ class FileAdoptionBatchTest extends KernelTestBase {
     $form_object->submitForm([], $form_state);
 
     $context = [];
-    do {
+    FileAdoptionForm::batchScanStep($context);
+
+    $count = $this->container->get('database')
+      ->select('file_adoption_orphans')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(20, $count);
+    $this->assertEmpty($context['finished']);
+
+    while (empty($context['finished'])) {
       FileAdoptionForm::batchScanStep($context);
-    } while (empty($context['finished']));
+    }
     FileAdoptionForm::batchScanFinished(TRUE, $context['results'], []);
 
     $count = $this->container->get('database')
@@ -178,10 +188,21 @@ class FileAdoptionBatchTest extends KernelTestBase {
 
     $context = [];
     $iterations = 0;
-    do {
+    FileAdoptionForm::batchScanStep($context);
+    $iterations++;
+
+    $count = $this->container->get('database')
+      ->select('file_adoption_orphans')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(10, $count);
+    $this->assertEmpty($context['finished']);
+
+    while (empty($context['finished'])) {
       FileAdoptionForm::batchScanStep($context);
       $iterations++;
-    } while (empty($context['finished']));
+    }
     FileAdoptionForm::batchScanFinished(TRUE, $context['results'], []);
 
     $count = $this->container->get('database')


### PR DESCRIPTION
## Summary
- refactor FileScanner::scanBatchStep to store a directory stack
- process only `items_per_run` files per invocation and resume from sandbox
- update progress calculation
- test incremental processing in batch scans

## Testing
- `phpunit tests/src/Kernel/FileAdoptionBatchTest.php` *(fails: Class `Drupal\KernelTests\KernelTestBase` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866dbfa77d48331a86610a004575118