### PR TITLE
Add refresh links action

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The configuration form offers the following options:
   Symlinks discovered during the preview are still listed in a separate section
   under "Public Directory Contents Preview" with an `(ignored)` flag when this
   option is enabled.
+- **Refresh Links** – Rebuilds the `file_adoption_hardlinks` table by scanning
+  node content for file references.
 
 Changes are stored in `file_adoption.settings`.
 
@@ -45,6 +47,7 @@ If adoption is disabled, cron still records the orphaned files it finds in the
 `file_adoption_orphans` table so they can be reviewed later.
 Hardlink references between nodes and files are stored in the
 `file_adoption_hardlinks` table.
+Use **Refresh Links** on the configuration page to rebuild this table.
 The configuration page now only reads these saved results and never performs a
 scan automatically. Scans are triggered via cron or by clicking **Scan Now** on
 the configuration page.
@@ -56,6 +59,8 @@ To run a scan on demand:
 1. Visit the File Adoption configuration page at `/admin/reports/file-adoption`.
 2. Click **Scan Now** to see a list of files that would be adopted.
 3. Review the results and click **Adopt** to create the file entities.
+4. Use **Refresh Links** to update node references stored in
+   `file_adoption_hardlinks`.
 
 ## Batch Scanning
 

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -35,7 +35,8 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('file_adoption.hardlink_scanner')
     );
     $form_object->submitForm($form, $form_state);
 
@@ -72,7 +73,8 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('file_adoption.hardlink_scanner')
     );
     $form_object->submitForm($form, $form_state);
 
@@ -103,7 +105,8 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('file_adoption.hardlink_scanner')
     );
 
     $form = $form_object->buildForm([], $form_state);
@@ -137,7 +140,8 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('file_adoption.hardlink_scanner')
     );
 
     $form = $form_object->buildForm([], $form_state);
@@ -166,7 +170,8 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('file_adoption.hardlink_scanner')
     );
 
     $form = $form_object->buildForm([], $form_state);
@@ -191,7 +196,8 @@ class FileAdoptionFormTest extends KernelTestBase {
     $form_state = new FormState();
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('file_adoption.hardlink_scanner')
     );
 
     $form = $form_object->buildForm([], $form_state);
@@ -212,7 +218,8 @@ class FileAdoptionFormTest extends KernelTestBase {
     $form_state = new FormState();
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('file_adoption.hardlink_scanner')
     );
 
     $form = $form_object->buildForm([], $form_state);
@@ -247,7 +254,8 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('file_adoption.hardlink_scanner')
     );
     $form_object->submitForm([], $form_state);
 
@@ -278,7 +286,8 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('file_adoption.hardlink_scanner')
     );
     $form_object->submitForm([], $form_state);
 
@@ -307,7 +316,8 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('file_adoption.hardlink_scanner')
     );
     $form_object->submitForm([], $form_state);
 
@@ -337,7 +347,8 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('file_adoption.hardlink_scanner')
     );
     $form_object->submitForm([], $form_state);
 
@@ -365,7 +376,8 @@ class FileAdoptionFormTest extends KernelTestBase {
     $form_state = new FormState();
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system')
+      $this->container->get('file_system'),
+      $this->container->get('file_adoption.hardlink_scanner')
     );
 
     // Build the form to load results from the database.
@@ -394,6 +406,49 @@ class FileAdoptionFormTest extends KernelTestBase {
       ->execute()
       ->fetchField();
     $this->assertEquals(0, $count);
+  }
+
+  /**
+   * Tests refreshing hardlink references via the form.
+   */
+  public function testRefreshLinksAction() {
+    // Create a mock node body table.
+    $schema = [
+      'fields' => [
+        'entity_id' => [
+          'type' => 'int',
+          'unsigned' => TRUE,
+          'not null' => TRUE,
+        ],
+        'body_value' => [
+          'type' => 'text',
+          'size' => 'big',
+          'not null' => FALSE,
+        ],
+      ],
+      'primary key' => ['entity_id'],
+    ];
+    $this->container->get('database')->schema()->createTable('node__body', $schema);
+    $this->container->get('database')->insert('node__body')->fields([
+      'entity_id' => 1,
+      'body_value' => '<img src="/sites/default/files/sample.txt" />',
+    ])->execute();
+
+    $form_state = new FormState();
+    $form_state->setTriggeringElement(['#name' => 'refresh_links']);
+    $form_object = new FileAdoptionForm(
+      $this->container->get('file_adoption.file_scanner'),
+      $this->container->get('file_system'),
+      $this->container->get('file_adoption.hardlink_scanner')
+    );
+    $form_object->submitForm([], $form_state);
+
+    $count = $this->container->get('database')
+      ->select('file_adoption_hardlinks')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(1, $count);
   }
 
 }


### PR DESCRIPTION
## Summary
- add Refresh Links button to FileAdoptionForm
- call HardLinkScanner from form submit
- describe new action in form descriptions and README
- adjust tests for the new constructor
- add kernel test covering Refresh Links

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6866fb63c6708331830c196d133d4844