### PR TITLE
Add usage tracking when adopting files

### DIFF
--- a/file_adoption.services.yml
+++ b/file_adoption.services.yml
@@ -10,6 +10,7 @@ services:
       - '@database'
       - '@config.factory'
       - '@logger.channel.file_adoption'
+      - '@file.usage'
   file_adoption.hardlink_scanner:
     class: 'Drupal\file_adoption\HardLinkScanner'
     arguments:


### PR DESCRIPTION
## Summary
- inject file.usage service into FileScanner
- record usage entries for nodes referencing adopted files
- log when usage is added

## Testing
- `curl -I https://example.com` *(fails: CONNECT tunnel failed)*
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6866fd6f1df483318af62aef6fb72abf