### PR TITLE
Update cron to refresh hardlink data

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ The configuration form offers the following options:
   under "Public Directory Contents Preview" with an `(ignored)` flag when this
   option is enabled.
 - **Refresh Links** – Rebuilds the `file_adoption_hardlinks` table by scanning
-  node content for file references.
+  node content for file references. Cron performs this refresh automatically
+  before each scan.
 
 Changes are stored in `file_adoption.settings`.
 
@@ -47,7 +48,8 @@ If adoption is disabled, cron still records the orphaned files it finds in the
 `file_adoption_orphans` table so they can be reviewed later.
 Hardlink references between nodes and files are stored in the
 `file_adoption_hardlinks` table.
-Use **Refresh Links** on the configuration page to rebuild this table.
+Cron rebuilds this table automatically before scanning.
+Use **Refresh Links** on the configuration page to force a manual rebuild.
 The configuration page now only reads these saved results and never performs a
 scan automatically. Scans are triggered via cron or by clicking **Scan Now** on
 the configuration page.
@@ -59,8 +61,9 @@ To run a scan on demand:
 1. Visit the File Adoption configuration page at `/admin/reports/file-adoption`.
 2. Click **Scan Now** to see a list of files that would be adopted.
 3. Review the results and click **Adopt** to create the file entities.
-4. Use **Refresh Links** to update node references stored in
-   `file_adoption_hardlinks`.
+4. Use **Refresh Links** to manually update node references stored in
+   `file_adoption_hardlinks` if needed. Cron refreshes these links
+   automatically during its run.
 
 ## Batch Scanning
 

--- a/file_adoption.module
+++ b/file_adoption.module
@@ -12,7 +12,12 @@ function file_adoption_cron() {
   $config = \Drupal::config('file_adoption.settings');
   /** @var \Drupal\file_adoption\FileScanner $scanner */
   $scanner = \Drupal::service('file_adoption.file_scanner');
+  /** @var \Drupal\file_adoption\HardLinkScanner $link_scanner */
+  $link_scanner = \Drupal::service('file_adoption.hardlink_scanner');
   $limit = (int) $config->get('items_per_run');
+
+  // Rebuild hardlink references before processing files.
+  $link_scanner->refresh();
 
   if ($config->get('enable_adoption')) {
     $scanner->scanAndProcess(TRUE, $limit);

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -145,7 +145,7 @@ class FileAdoptionForm extends ConfigFormBase {
       // recent scan being triggered.
       if ($total === 0 && !$from_batch && $trigger !== 'scan') {
         $scan_results = NULL;
-        $this->messenger()->addStatus($this->t('No scan results found. Click "Scan Now", use "Refresh Links", or wait for cron.'));
+        $this->messenger()->addStatus($this->t('No scan results found. Click "Scan Now" or wait for cron. Link data is refreshed automatically.'));
       }
 
       // Persist loaded results so actions like "Adopt" can operate on them.


### PR DESCRIPTION
## Summary
- refresh hardlink references before cron scanning
- document automatic link refresh in README
- adjust message in settings form

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866fecbb928833187349d71a9a76cef