### PR TITLE
Allow storing multiple hardlink references

### DIFF
--- a/file_adoption.install
+++ b/file_adoption.install
@@ -77,11 +77,9 @@ function file_adoption_schema() {
       ],
     ],
     'primary key' => ['id'],
-    'unique keys' => [
-      'uri' => ['uri'],
-    ],
     'indexes' => [
       'nid' => ['nid'],
+      'uri' => ['uri'],
       'timestamp' => ['timestamp'],
     ],
   ];
@@ -121,4 +119,20 @@ function file_adoption_update_10004() {
     $db->schema()->createTable('file_adoption_hardlinks', $schema);
   }
   return t('Added file_adoption_hardlinks table.');
+}
+
+/**
+ * Drops the hardlink URI unique index and adds a regular index.
+ */
+function file_adoption_update_10005() {
+  $schema = \Drupal::database()->schema();
+  if ($schema->tableExists('file_adoption_hardlinks')) {
+    if ($schema->uniqueKeyExists('file_adoption_hardlinks', 'uri')) {
+      $schema->dropUniqueKey('file_adoption_hardlinks', 'uri');
+    }
+    if (!$schema->indexExists('file_adoption_hardlinks', 'uri')) {
+      $schema->addIndex('file_adoption_hardlinks', 'uri', ['uri']);
+    }
+  }
+  return t('Adjusted indexes for file_adoption_hardlinks.');
 }

--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -807,6 +807,7 @@ class FileScanner {
 
             // Record node usage based on hardlink references.
             $hardlinks = $this->database->select('file_adoption_hardlinks', 'h')
+                ->distinct()
                 ->fields('h', ['nid'])
                 ->condition('uri', $uri)
                 ->execute()

--- a/src/HardLinkScanner.php
+++ b/src/HardLinkScanner.php
@@ -83,9 +83,11 @@ class HardLinkScanner {
                         }
                         $uri = $this->canonicalizeUri($uri);
                         $this->database->merge('file_adoption_hardlinks')
-                            ->key(['uri' => $uri])
-                            ->fields([
+                            ->key([
                                 'nid' => $record->entity_id,
+                                'uri' => $uri,
+                            ])
+                            ->fields([
                                 'timestamp' => time(),
                             ])
                             ->execute();


### PR DESCRIPTION
## Summary
- relax the unique constraint on file_adoption_hardlinks and add an index
- upsert hardlink records by node and URI
- fetch unique nids when adopting files
- test storing links from multiple nodes
- add an update hook to convert existing tables

## Testing
- `vendor/bin/phpunit -c core modules/custom/file_adoption/tests/src/Kernel/HardLinkScannerTest.php` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a742603a08331a83799757666c6e5