### PR TITLE
Implement hard link scan controller summary

### DIFF
--- a/file_adoption.permissions.yml
+++ b/file_adoption.permissions.yml
@@ -1,1 +1,5 @@
-# This module uses the core 'administer site configuration' permission for access.
+# Custom permissions for File Adoption.
+
+scan hardlink usage:
+  title: 'Scan for hard-coded file links'
+  description: 'Refreshes file_adoption_hardlinks and shows detected node references.'

--- a/file_adoption.routing.yml
+++ b/file_adoption.routing.yml
@@ -12,4 +12,4 @@ file_adoption.scan_links:
     _controller: '\Drupal\file_adoption\Controller\LinkScanController::scanAndAddUsage'
     _title: 'Scan Hard Links'
   requirements:
-    _permission: 'administer site configuration'
+    _permission: 'scan hardlink usage'

--- a/src/Controller/LinkScanController.php
+++ b/src/Controller/LinkScanController.php
@@ -68,12 +68,20 @@ class LinkScanController extends ControllerBase {
       ->fetchAll();
 
     if ($records) {
+      $summary = [];
       foreach ($records as $record) {
-        $this->messenger->addWarning($this->t('Node @nid links to @uri', [
-          '@nid' => $record->nid,
-          '@uri' => $record->uri,
-        ]));
+        $summary[$record->nid][] = $record->uri;
       }
+
+      $lines = [];
+      foreach ($summary as $nid => $uris) {
+        $lines[] = $this->t('Node @nid: @uris', [
+          '@nid' => $nid,
+          '@uris' => implode(', ', $uris),
+        ]);
+      }
+
+      $this->messenger->addWarning(implode("\n", $lines));
     }
     else {
       $this->messenger->addStatus($this->t('No hard coded links found.'));

--- a/tests/src/Kernel/LinkScanControllerTest.php
+++ b/tests/src/Kernel/LinkScanControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\Tests\file_adoption\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\file_adoption\Controller\LinkScanController;
+
+/**
+ * Tests the LinkScanController output.
+ *
+ * @group file_adoption
+ */
+class LinkScanControllerTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'file', 'file_adoption'];
+
+  /**
+   * Ensures the scan controller reports detected links.
+   */
+  public function testScanAndAddUsageMessage() {
+    $schema = [
+      'fields' => [
+        'entity_id' => [
+          'type' => 'int',
+          'unsigned' => TRUE,
+          'not null' => TRUE,
+        ],
+        'body_value' => [
+          'type' => 'text',
+          'size' => 'big',
+          'not null' => FALSE,
+        ],
+      ],
+      'primary key' => ['entity_id'],
+    ];
+    $db = $this->container->get('database');
+    $db->schema()->createTable('node__body', $schema);
+    $db->insert('node__body')->fields([
+      'entity_id' => 1,
+      'body_value' => '<a href="/sites/default/files/test.txt">file</a>',
+    ])->execute();
+
+    \Drupal::messenger()->deleteAll();
+
+    $controller = LinkScanController::create($this->container);
+    $controller->scanAndAddUsage();
+
+    $messages = \Drupal::messenger()->messagesByType('warning');
+    $this->assertNotEmpty($messages);
+    $message = (string) reset($messages);
+    $this->assertStringContainsString('1', $message);
+    $this->assertStringContainsString('public://test.txt', $message);
+  }
+
+}
+


### PR DESCRIPTION
## Summary
- aggregate link scan results into a single warning message
- add dedicated permission and update routing
- add Kernel test for controller output

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption/tests/src/Kernel/LinkScanControllerTest.php` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a78af1454833180e44846e6184f58