### PR TITLE
Add hardlink warnings after refresh

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -385,12 +385,25 @@ class FileAdoptionForm extends ConfigFormBase {
     }
     elseif ($trigger === 'refresh_links') {
       $this->hardLinkScanner->refresh();
-      $count = (int) \Drupal::database()
-        ->select('file_adoption_hardlinks')
-        ->countQuery()
+
+      $database = \Drupal::database();
+      $records = $database->select('file_adoption_hardlinks', 'h')
+        ->fields('h', ['nid', 'uri'])
+        ->orderBy('nid')
         ->execute()
-        ->fetchField();
-      $this->messenger()->addStatus($this->t('@count link(s) stored.', ['@count' => $count]));
+        ->fetchAll();
+
+      foreach ($records as $record) {
+        $this->messenger()->addWarning($this->t('Node @nid links to @uri', [
+          '@nid' => $record->nid,
+          '@uri' => $record->uri,
+        ]));
+      }
+
+      $this->messenger()->addStatus($this->t('@count link(s) stored.', [
+        '@count' => count($records),
+      ]));
+
       $form_state->setRebuild(TRUE);
     }
     elseif ($trigger === 'adopt') {

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -434,6 +434,8 @@ class FileAdoptionFormTest extends KernelTestBase {
       'body_value' => '<img src="/sites/default/files/sample.txt" />',
     ])->execute();
 
+    \Drupal::messenger()->deleteAll();
+
     $form_state = new FormState();
     $form_state->setTriggeringElement(['#name' => 'refresh_links']);
     $form_object = new FileAdoptionForm(
@@ -442,6 +444,12 @@ class FileAdoptionFormTest extends KernelTestBase {
       $this->container->get('file_adoption.hardlink_scanner')
     );
     $form_object->submitForm([], $form_state);
+
+    $messages = \Drupal::messenger()->messagesByType('warning');
+    $this->assertCount(1, $messages);
+    $message = (string) reset($messages);
+    $this->assertStringContainsString('1', $message);
+    $this->assertStringContainsString('public://sample.txt', $message);
 
     $count = $this->container->get('database')
       ->select('file_adoption_hardlinks')


### PR DESCRIPTION
## Summary
- display hardlinked node/URI pairs after running `Refresh Links`
- test warning output from the form

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686a79f03c3c8331b364959de55e0d8c