### PR TITLE
Track hardlinks for each node

### DIFF
--- a/file_adoption.install
+++ b/file_adoption.install
@@ -83,7 +83,7 @@ function file_adoption_schema() {
       'timestamp' => ['timestamp'],
     ],
     'unique keys' => [
-      'uri_nid' => ['uri', 'nid'],
+      'nid_uri' => ['nid', 'uri'],
     ],
   ];
   return $schema;
@@ -154,4 +154,23 @@ function file_adoption_update_10006() {
     }
   }
   return t('Added composite unique key on URI and node ID.');
+}
+
+/**
+ * Replaces the unique key on URI and node ID with nid and uri order.
+ */
+function file_adoption_update_10007() {
+  $schema = \Drupal::database()->schema();
+  if ($schema->tableExists('file_adoption_hardlinks')) {
+    if ($schema->uniqueKeyExists('file_adoption_hardlinks', 'uri_nid')) {
+      $schema->dropUniqueKey('file_adoption_hardlinks', 'uri_nid');
+    }
+    if (!$schema->uniqueKeyExists('file_adoption_hardlinks', 'nid_uri')) {
+      $schema->addUniqueKey('file_adoption_hardlinks', 'nid_uri', ['nid', 'uri']);
+    }
+    if (!$schema->indexExists('file_adoption_hardlinks', 'uri')) {
+      $schema->addIndex('file_adoption_hardlinks', 'uri', ['uri']);
+    }
+  }
+  return t('Added nid_uri composite unique key.');
 }

--- a/src/HardLinkScanner.php
+++ b/src/HardLinkScanner.php
@@ -90,8 +90,8 @@ class HardLinkScanner {
                         $uri = $this->canonicalizeUri($uri);
                         $this->database->merge('file_adoption_hardlinks')
                             ->key([
-                                'uri' => $uri,
                                 'nid' => $record->entity_id,
+                                'uri' => $uri,
                             ])
                             ->fields([
                                 'timestamp' => time(),

--- a/tests/src/Kernel/HardLinkScannerTest.php
+++ b/tests/src/Kernel/HardLinkScannerTest.php
@@ -138,4 +138,53 @@ class HardLinkScannerTest extends KernelTestBase {
     $this->assertEquals(['nid' => 1, 'uri' => 'public://test.txt'], $record);
   }
 
+  /**
+   * Ensures links in multiple node tables are all recorded.
+   */
+  public function testRefreshScansMultipleTables() {
+    $schema = [
+      'fields' => [
+        'entity_id' => [
+          'type' => 'int',
+          'unsigned' => TRUE,
+          'not null' => TRUE,
+        ],
+        'body_value' => [
+          'type' => 'text',
+          'size' => 'big',
+          'not null' => FALSE,
+        ],
+      ],
+      'primary key' => ['entity_id'],
+    ];
+
+    $db = $this->container->get('database');
+    $db->schema()->createTable('node__body', $schema);
+    $db->schema()->createTable('node_revision__body', $schema);
+    $db->insert('node__body')->fields([
+      'entity_id' => 1,
+      'body_value' => '<a href="/sites/default/files/test.txt">file</a>',
+    ])->execute();
+    $db->insert('node_revision__body')->fields([
+      'entity_id' => 2,
+      'body_value' => '<a href="/sites/default/files/test.txt">file</a>',
+    ])->execute();
+
+    /** @var \Drupal\file_adoption\HardLinkScanner $scanner */
+    $scanner = $this->container->get('file_adoption.hardlink_scanner');
+    $scanner->refresh();
+
+    $records = $db->select('file_adoption_hardlinks', 'h')
+      ->fields('h', ['nid', 'uri'])
+      ->orderBy('nid')
+      ->execute()
+      ->fetchAllKeyed(0, 1);
+
+    $expected = [
+      1 => 'public://test.txt',
+      2 => 'public://test.txt',
+    ];
+    $this->assertEquals($expected, $records);
+  }
+
 }


### PR DESCRIPTION
## Summary
- enforce nid+uri uniqueness in the hardlink schema
- adjust HardLinkScanner to merge on nid/uri pair
- provide an update hook for existing sites
- test scanning multiple node tables for the same file

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686a7c03eda0833199749d206a3a2f01