### PR TITLE
Resolve merge markers and fix update hooks

### DIFF
--- a/file_adoption.install
+++ b/file_adoption.install
@@ -130,8 +130,13 @@ function file_adoption_update_10004() {
 function file_adoption_update_10005() {
   $schema = \Drupal::database()->schema();
   if ($schema->tableExists('file_adoption_hardlinks')) {
-    if ($schema->uniqueKeyExists('file_adoption_hardlinks', 'uri')) {
-      $schema->dropUniqueKey('file_adoption_hardlinks', 'uri');
+    if (method_exists($schema, 'uniqueKeyExists')) {
+      if ($schema->uniqueKeyExists('file_adoption_hardlinks', 'uri')) {
+        $schema->dropUniqueKey('file_adoption_hardlinks', 'uri');
+      }
+    }
+    elseif ($schema->indexExists('file_adoption_hardlinks', 'uri')) {
+      $schema->dropIndex('file_adoption_hardlinks', 'uri');
     }
     if (!$schema->indexExists('file_adoption_hardlinks', 'uri')) {
       $schema->addIndex('file_adoption_hardlinks', 'uri', ['uri']);
@@ -146,11 +151,21 @@ function file_adoption_update_10005() {
 function file_adoption_update_10006() {
   $schema = \Drupal::database()->schema();
   if ($schema->tableExists('file_adoption_hardlinks')) {
-    if ($schema->uniqueKeyExists('file_adoption_hardlinks', 'uri')) {
-      $schema->dropUniqueKey('file_adoption_hardlinks', 'uri');
+    if (method_exists($schema, 'uniqueKeyExists')) {
+      if ($schema->uniqueKeyExists('file_adoption_hardlinks', 'uri')) {
+        $schema->dropUniqueKey('file_adoption_hardlinks', 'uri');
+      }
+      if (!$schema->uniqueKeyExists('file_adoption_hardlinks', 'uri_nid')) {
+        $schema->addUniqueKey('file_adoption_hardlinks', 'uri_nid', ['uri', 'nid']);
+      }
     }
-    if (!$schema->uniqueKeyExists('file_adoption_hardlinks', 'uri_nid')) {
-      $schema->addUniqueKey('file_adoption_hardlinks', 'uri_nid', ['uri', 'nid']);
+    else {
+      if ($schema->indexExists('file_adoption_hardlinks', 'uri')) {
+        $schema->dropIndex('file_adoption_hardlinks', 'uri');
+      }
+      if (!$schema->indexExists('file_adoption_hardlinks', 'uri_nid')) {
+        $schema->addUniqueKey('file_adoption_hardlinks', 'uri_nid', ['uri', 'nid']);
+      }
     }
   }
   return t('Added composite unique key on URI and node ID.');
@@ -162,11 +177,21 @@ function file_adoption_update_10006() {
 function file_adoption_update_10007() {
   $schema = \Drupal::database()->schema();
   if ($schema->tableExists('file_adoption_hardlinks')) {
-    if ($schema->uniqueKeyExists('file_adoption_hardlinks', 'uri_nid')) {
-      $schema->dropUniqueKey('file_adoption_hardlinks', 'uri_nid');
+    if (method_exists($schema, 'uniqueKeyExists')) {
+      if ($schema->uniqueKeyExists('file_adoption_hardlinks', 'uri_nid')) {
+        $schema->dropUniqueKey('file_adoption_hardlinks', 'uri_nid');
+      }
+      if (!$schema->uniqueKeyExists('file_adoption_hardlinks', 'nid_uri')) {
+        $schema->addUniqueKey('file_adoption_hardlinks', 'nid_uri', ['nid', 'uri']);
+      }
     }
-    if (!$schema->uniqueKeyExists('file_adoption_hardlinks', 'nid_uri')) {
-      $schema->addUniqueKey('file_adoption_hardlinks', 'nid_uri', ['nid', 'uri']);
+    else {
+      if ($schema->indexExists('file_adoption_hardlinks', 'uri_nid')) {
+        $schema->dropIndex('file_adoption_hardlinks', 'uri_nid');
+      }
+      if (!$schema->indexExists('file_adoption_hardlinks', 'nid_uri')) {
+        $schema->addUniqueKey('file_adoption_hardlinks', 'nid_uri', ['nid', 'uri']);
+      }
     }
     if (!$schema->indexExists('file_adoption_hardlinks', 'uri')) {
       $schema->addIndex('file_adoption_hardlinks', 'uri', ['uri']);

--- a/file_adoption.routing.yml
+++ b/file_adoption.routing.yml
@@ -12,8 +12,4 @@ file_adoption.scan_links:
     _controller: '\Drupal\file_adoption\Controller\LinkScanController::scanAndAddUsage'
     _title: 'Scan Hard Links'
   requirements:
-<<<<<<< ours
     _permission: 'scan hardlink usage'
-=======
-    _permission: 'administer site configuration'
->>>>>>> theirs


### PR DESCRIPTION
## Summary
- remove stray merge markers from routing file
- fall back to `indexExists` when `uniqueKeyExists` isn't implemented

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a7f1441588331aef02e9904e6cdfc