### PR TITLE
Cache table discovery for HardLinkScanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Hardlink references are stored in the `file_adoption_hardlinks` table. Entries
 include the node ID when found in node tables or the source table name and row
 identifier for links discovered elsewhere.
 Cron rebuilds this table automatically before scanning.
+Table and field discovery is cached and logged when built. Clear Drupal caches to force rebuilding.
 Use **Refresh Links** on the configuration page to force a manual rebuild.
 The configuration page now only reads these saved results and never performs a
 scan automatically. Scans are triggered via cron or by clicking **Scan Now** on

--- a/file_adoption.services.yml
+++ b/file_adoption.services.yml
@@ -16,3 +16,4 @@ services:
     arguments:
       - '@database'
       - '@logger.channel.file_adoption'
+      - '@cache.default'


### PR DESCRIPTION
## Summary
- cache table & field map in HardLinkScanner
- inject cache backend via services.yml
- log cache contents on build
- document cache behaviour in README
- add kernel test verifying cache creation

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686bd54789508331a11e22a3f90984bb