### PR TITLE
Cache text field discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Hardlink references are stored in the `file_adoption_hardlinks` table. Entries
 include the node ID when found in node tables or the source table name and row
 identifier for links discovered elsewhere.
 Cron rebuilds this table automatically before scanning.
-Table and field discovery is cached and logged when built. Clear Drupal caches to force rebuilding.
+Table and field discovery is cached in the `file_adoption` cache bin and logged when built.
+Clear Drupal caches (e.g. `drush cr`) or delete the `hardlink_text_fields` entry to force rebuilding.
 Use **Refresh Links** on the configuration page to force a manual rebuild.
 The configuration page now only reads these saved results and never performs a
 scan automatically. Scans are triggered via cron or by clicking **Scan Now** on

--- a/file_adoption.services.yml
+++ b/file_adoption.services.yml
@@ -16,4 +16,11 @@ services:
     arguments:
       - '@database'
       - '@logger.channel.file_adoption'
-      - '@cache.default'
+      - '@cache.file_adoption'
+
+  cache.file_adoption:
+    class: Drupal\Core\Cache\CacheBackendInterface
+    factory: cache_factory:get
+    arguments: ['file_adoption']
+    tags:
+      - { name: cache.bin }

--- a/src/HardLinkScanner.php
+++ b/src/HardLinkScanner.php
@@ -37,7 +37,7 @@ class HardLinkScanner {
      *
      * @var string
      */
-    protected $cacheId = 'file_adoption.hardlink_fields';
+    protected $cacheId = 'hardlink_text_fields';
 
     /**
      * SQL LIKE pattern used to narrow matches.
@@ -70,9 +70,11 @@ class HardLinkScanner {
     }
 
     /**
-     * Loads the cached table/field map or builds it when missing.
+     * Retrieves a map of tables to text-based fields.
+     *
+     * Results are cached in the file_adoption cache bin.
      */
-    protected function getFieldMap(): array {
+    private function getTextFields(): array {
         $cached = $this->cache->get($this->cacheId);
         if ($cached) {
             return $cached->data;
@@ -120,7 +122,7 @@ class HardLinkScanner {
         }
 
         $this->cache->set($this->cacheId, $map);
-        $this->logger->info('HardLinkScanner cache built: @map', ['@map' => var_export($map, TRUE)]);
+        $this->logger->info('HardLinkScanner field map built: @map', ['@map' => var_export($map, TRUE)]);
 
         return $map;
     }
@@ -133,7 +135,7 @@ class HardLinkScanner {
      */
     public function refresh(): void {
         $schema = $this->database->schema();
-        $map = $this->getFieldMap();
+        $map = $this->getTextFields();
 
         // Clear existing data.
         $this->database->truncate('file_adoption_hardlinks')->execute();

--- a/tests/src/Kernel/HardLinkScannerTest.php
+++ b/tests/src/Kernel/HardLinkScannerTest.php
@@ -17,6 +17,14 @@ class HardLinkScannerTest extends KernelTestBase {
   protected static $modules = ['system', 'user', 'file', 'file_adoption'];
 
   /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->container->get('cache.file_adoption')->delete('hardlink_text_fields');
+  }
+
+  /**
    * Verifies link references are stored during a refresh.
    */
   public function testRefreshStoresLinks() {
@@ -274,14 +282,14 @@ class HardLinkScannerTest extends KernelTestBase {
     $db = $this->container->get('database');
     $db->schema()->createTable('node__body', $schema);
 
-    $cache = $this->container->get('cache.default');
-    $cache->delete('file_adoption.hardlink_fields');
+    $cache = $this->container->get('cache.file_adoption');
+    $cache->delete('hardlink_text_fields');
 
     /** @var \Drupal\file_adoption\HardLinkScanner $scanner */
     $scanner = $this->container->get('file_adoption.hardlink_scanner');
     $scanner->refresh();
 
-    $cached = $cache->get('file_adoption.hardlink_fields');
+    $cached = $cache->get('hardlink_text_fields');
     $this->assertNotEmpty($cached);
     $this->assertArrayHasKey('node__body', $cached->data);
     $this->assertContains('body_value', $cached->data['node__body']);


### PR DESCRIPTION
## Summary
- provide a cache bin for hardlink scanning
- store text field discovery in cache
- document the cache in README
- reset the cache in HardLinkScannerTest

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bdb31af7083319b3b5fd8b4cfa6d3