### PR TITLE
Align tests with cron-based workflow

### DIFF
--- a/tests/src/Kernel/FileAdoptionCronTest.php
+++ b/tests/src/Kernel/FileAdoptionCronTest.php
@@ -116,3 +116,4 @@ class FileAdoptionCronTest extends KernelTestBase {
     $this->assertEquals(1, $count);
   }
 
+}

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -25,7 +25,9 @@ class FileAdoptionFormTest extends KernelTestBase {
     $this->config('system.file')->set('path.public', $public)->save();
 
     file_put_contents("$public/orphan.txt", 'x');
-    $this->container->get('file_adoption.file_scanner')->recordOrphans();
+
+    // Use cron to populate the orphan table so the form reflects typical usage.
+    file_adoption_cron();
 
     $form_state = new FormState();
     $form_object = new FileAdoptionForm(
@@ -73,7 +75,9 @@ class FileAdoptionFormTest extends KernelTestBase {
     $this->config('system.file')->set('path.public', $public)->save();
 
     file_put_contents("$public/orphan.txt", 'x');
-    $this->container->get('file_adoption.file_scanner')->recordOrphans();
+
+    // Populate the orphan list via cron to mirror real behavior.
+    file_adoption_cron();
 
     $form_state = new FormState();
     $form_object = new FileAdoptionForm(


### PR DESCRIPTION
## Summary
- update FileAdoptionFormTest to run cron to populate orphan data
- fix missing closing brace in FileAdoptionCronTest

## Testing
- `php -l tests/src/Kernel/FileAdoptionFormTest.php`
- `php -l tests/src/Kernel/FileAdoptionCronTest.php`
- `php -l tests/src/Kernel/FileScannerTest.php`
- `../vendor/bin/phpunit -c core modules/custom/file_adoption/tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686c02498e3c8331aa16e40da63bfe4c