### PR TITLE
Fix missing closing brace in FileAdoptionForm

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -231,6 +231,9 @@ class FileAdoptionForm extends ConfigFormBase {
       ];
     }
 
+    // Close the outer scan results check.
+    }
+
     return $form;
   }
 


### PR DESCRIPTION
## Summary
- close the outer `if ($scan_results !== NULL)` block in `FileAdoptionForm`

## Testing
- `php -l src/Form/FileAdoptionForm.php`
- `phpunit tests` *(fails: Unclosed '{' on line 13)*

------
https://chatgpt.com/codex/tasks/task_e_686c018707e483318caeb4679114d0ab