### PR TITLE
Fix admin form structure

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -191,7 +191,8 @@ class FileAdoptionForm extends ConfigFormBase {
           ],
         ];
       }
-    
+    }
+
     $form['actions'] = [
       '#type' => 'actions',
     ];
@@ -200,7 +201,6 @@ class FileAdoptionForm extends ConfigFormBase {
       '#value' => $this->t('Save Configuration'),
       '#button_type' => 'primary',
     ];
-
 
     if ($scan_results !== NULL) {
       $managed_list = array_map([Html::class, 'escape'], $scan_results['to_manage']);
@@ -221,7 +221,6 @@ class FileAdoptionForm extends ConfigFormBase {
           '#markup' => Markup::create($markup),
         ];
       }
-
 
       $form['actions']['adopt'] = [
         '#type' => 'submit',


### PR DESCRIPTION
## Summary
- keep actions outside orphan results check
- only show Adopt button when orphan results exist

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: No such file or directory)*
- `vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: No such file or directory)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c0399842883318bba81e34d24af73