### PR TITLE
Clarify FileScanner limit behavior

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -158,7 +158,7 @@ class FileScanner {
      * @param bool $adopt
      *   Whether matching orphan files should be adopted.
      * @param int $limit
-     *   Maximum number of orphans to adopt. 0 means no limit.
+     *   Maximum number of orphans to adopt.
      *
      * @return array
      *   An associative array with the keys 'files', 'orphans' and 'adopted'.
@@ -382,7 +382,7 @@ class FileScanner {
      * orphan table before scanning and stops once the limit is reached.
      *
      * @param int $limit
-     *   Maximum number of orphans to record. 0 means no limit.
+     *   Maximum number of orphans to record.
      *
      * @return array
      *   Counts for 'files' and 'orphans'.


### PR DESCRIPTION
## Summary
- update comments to stop claiming `0` means unlimited

## Testing
- `composer install`
- `./vendor/bin/phpunit -c core modules/custom/file_adoption/tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686c23019fec8331abba1ef5881808c3