### PR TITLE
Adjust cron frequency options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,8 @@ The configuration form offers the following options:
 - **Ignore Symlinks** – When enabled, symbolic links are skipped during scanning,
   preventing loops or slowdowns caused by symlinks.
   Symlinks discovered during scanning are still listed under the "Symlinks"
-  section with an `(ignored)` flag when this option is enabled.
 - **Cron Frequency** – How often cron should run file adoption tasks. Options
-  include hourly, daily, weekly, monthly, or yearly.
+  include every cron run, hourly, daily, or weekly.
 - **Verbose Logging** – When enabled, additional debug information is written to
   the log during scans and adoption. This is on by default.
 

--- a/file_adoption.module
+++ b/file_adoption.module
@@ -13,11 +13,10 @@ function file_adoption_cron() {
   $state = \Drupal::state();
   $frequency = $config->get('cron_frequency') ?: 'daily';
   $intervals = [
+    'every' => 0,
     'hourly' => 3600,
     'daily' => 86400,
     'weekly' => 604800,
-    'monthly' => 2592000,
-    'yearly' => 31536000,
   ];
   $last = (int) $state->get('file_adoption.last_cron', 0);
   $now = time();

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -94,11 +94,10 @@ class FileAdoptionForm extends ConfigFormBase {
     ];
 
     $options = [
+      'every' => $this->t('Every cron run'),
       'hourly' => $this->t('Hourly'),
       'daily' => $this->t('Daily'),
       'weekly' => $this->t('Weekly'),
-      'monthly' => $this->t('Monthly'),
-      'yearly' => $this->t('Yearly'),
     ];
     $form['cron_frequency'] = [
       '#type' => 'select',


### PR DESCRIPTION
## Summary
- remove monthly and yearly cron frequencies
- add `every` frequency option for each cron run
- update README and form options
- adapt cron tests for new options

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c2c381a1883319e6bf86f46471247