### PR TITLE
Respect verbose logging for adoption notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ The configuration form offers the following options:
 - **Cron Frequency** – How often cron should run file adoption tasks. Options
   include every cron run, hourly, daily, or weekly.
 - **Verbose Logging** – When enabled, additional debug information is written to
-  the log during scans and adoption. This is on by default.
+  the log during scans and adoption. This is on by default. Adoption success
+  messages are only recorded when verbose logging is enabled.
 
 Changes are stored in `file_adoption.settings`.
 

--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -854,7 +854,9 @@ class FileScanner {
         ->condition('uri', $uri)
         ->execute();
 
-      $this->logger->notice('Adopted orphan file @file', ['@file' => $uri]);
+      if ($verbose) {
+        $this->logger->notice('Adopted orphan file @file', ['@file' => $uri]);
+      }
       return TRUE;
     }
     catch (\Exception $e) {


### PR DESCRIPTION
## Summary
- conditionally log adoption notices only if verbose logging is enabled
- document how adoption messages follow the verbose logging setting

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption/tests/src/Kernel` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686c316993788331b2a80b92a6f51d1e