### PR TITLE
Add asset injector ignore pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ for files that are not tracked by Drupal's `file_managed` table. Identified
 The configuration form offers the following options:
 
 - **Ignore Patterns** – Comma or newline separated patterns (relative to
-  `public://`) that should be skipped when scanning.
+  `public://`) that should be skipped when scanning. The default configuration
+  skips directories such as `css/*`, `js/*`, `private/*`, `webforms/*`,
+  `config_*`, `media-icons/*`, `php/*`, `styles/*`, and `asset_injector/*`.
 - **Enable Adoption** – When checked, cron will automatically adopt orphaned
   files using the configured settings.
 - **Items per cron run** – Maximum number of files processed and displayed per

--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -7,6 +7,7 @@ ignore_patterns: |
   media-icons/*
   php/*
   styles/*
+  asset_injector/*
 enable_adoption: false
 items_per_run: 20
 ignore_symlinks: false

--- a/file_adoption.install
+++ b/file_adoption.install
@@ -94,3 +94,22 @@ function file_adoption_update_10005() {
   }
   return t('Added verbose_logging setting.');
 }
+
+/**
+ * Appends asset_injector/* to ignore_patterns by default.
+ */
+function file_adoption_update_10006() {
+  $config = \Drupal::configFactory()->getEditable('file_adoption.settings');
+  $patterns = $config->get('ignore_patterns') ?: '';
+  $list = preg_split("/(\r\n|\n|\r|,)/", $patterns);
+  $list = array_map('trim', $list);
+  if (!in_array('asset_injector/*', $list, TRUE)) {
+    $patterns = trim($patterns);
+    if ($patterns !== '') {
+      $patterns .= "\n";
+    }
+    $patterns .= 'asset_injector/*';
+    $config->set('ignore_patterns', $patterns)->save();
+  }
+  return t('Added asset_injector/* ignore pattern.');
+}


### PR DESCRIPTION
## Summary
- append asset_injector/* default ignore pattern
- provide update hook to add the new pattern for existing installs
- document default ignore patterns in README

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686cbd9837488331b462f09f3bcce017