### PR TITLE
Remove unused services and injection

### DIFF
--- a/file_adoption.services.yml
+++ b/file_adoption.services.yml
@@ -10,11 +10,4 @@ services:
       - '@database'
       - '@config.factory'
       - '@logger.channel.file_adoption'
-      - '@file.usage'
 
-  cache.file_adoption:
-    class: Drupal\Core\Cache\CacheBackendInterface
-    factory: cache_factory:get
-    arguments: ['file_adoption']
-    tags:
-      - { name: cache.bin }

--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -6,7 +6,6 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\File\FileSystemInterface;
 use Psr\Log\LoggerInterface;
-use Drupal\file\FileUsage\FileUsageInterface;
 use Drupal\file\Entity\File;
 
 /**
@@ -42,12 +41,6 @@ class FileScanner {
    */
   protected $logger;
 
-  /**
-   * File usage tracking service.
-   *
-   * @var \Drupal\file\FileUsage\FileUsageInterface
-   */
-  protected $fileUsage;
 
   /**
    * Cached list of URIs that are already managed.
@@ -82,13 +75,12 @@ class FileScanner {
    * @param \Psr\Log\LoggerInterface $logger
    *   The logger channel for the file_adoption module.
    */
-  public function __construct(FileSystemInterface $file_system, Connection $database, ConfigFactoryInterface $config_factory, LoggerInterface $logger, FileUsageInterface $file_usage) {
+  public function __construct(FileSystemInterface $file_system, Connection $database, ConfigFactoryInterface $config_factory, LoggerInterface $logger) {
     $this->fileSystem = $file_system;
     $this->database = $database;
     $this->configFactory = $config_factory;
     // Use the provided logger channel (file_adoption).
     $this->logger = $logger;
-    $this->fileUsage = $file_usage;
   }
 
   /**

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -5,7 +5,6 @@ namespace Drupal\file_adoption\Form;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\file_adoption\FileScanner;
-use Drupal\Core\File\FileSystemInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Component\Utility\Html;
@@ -22,12 +21,6 @@ class FileAdoptionForm extends ConfigFormBase {
   */
   protected $fileScanner;
 
-  /**
-   * The file system service.
-   *
-   * @var \Drupal\Core\File\FileSystemInterface
-   */
-  protected $fileSystem;
 
 
 
@@ -37,9 +30,8 @@ class FileAdoptionForm extends ConfigFormBase {
    * @param \Drupal\file_adoption\FileScanner $fileScanner
    *   The file scanner service.
    */
-  public function __construct(FileScanner $fileScanner, FileSystemInterface $fileSystem) {
+  public function __construct(FileScanner $fileScanner) {
     $this->fileScanner = $fileScanner;
-    $this->fileSystem = $fileSystem;
   }
 
   /**
@@ -47,8 +39,7 @@ class FileAdoptionForm extends ConfigFormBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('file_adoption.file_scanner'),
-      $container->get('file_system')
+      $container->get('file_adoption.file_scanner')
     );
   }
 

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -31,8 +31,7 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form_state = new FormState();
     $form_object = new FileAdoptionForm(
-      $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system'),
+      $this->container->get('file_adoption.file_scanner')
     );
     $form = $form_object->buildForm([], $form_state);
 
@@ -51,8 +50,7 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form_state = new FormState();
     $form_object = new FileAdoptionForm(
-      $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system'),
+      $this->container->get('file_adoption.file_scanner')
     );
     $form = $form_object->buildForm([], $form_state);
 
@@ -81,8 +79,7 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form_state = new FormState();
     $form_object = new FileAdoptionForm(
-      $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('file_system'),
+      $this->container->get('file_adoption.file_scanner')
     );
 
     $form = $form_object->buildForm([], $form_state);


### PR DESCRIPTION
## Summary
- drop unused file_usage injection in `FileScanner`
- remove the cache service definition
- simplify `FileAdoptionForm` constructor
- adjust kernel tests for the new constructor

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686ce036fbac8331a77c751702bafc67