### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ When **Enable Adoption** is active the same run will also register those files
 as entities. The configuration page merely reads from this table, so the results
 shown there reflect the last cron execution rather than a fresh scan.
 
-
-
-# file_adoption
-
 ## Running Tests
 
 These tests rely on Drupal's core testing environment. Make sure your Drupal


### PR DESCRIPTION
## Summary
- remove duplicate `# file_adoption` header from README
- connect Cron Integration section directly to "Running Tests"

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686ce9fb1af08331982919dde3ec9f18