### PR TITLE
Implement uninstall cleanup for File Adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,8 @@ From the module directory you can run:
 
 The tests are located under the `tests/` directory and include kernel tests for
 the `FileScanner` service and the configuration form.
+
+## Uninstall
+
+Uninstalling the module removes all of its configuration and drops the
+`file_adoption_orphans` table so no leftover data remains.

--- a/file_adoption.install
+++ b/file_adoption.install
@@ -132,3 +132,15 @@ function file_adoption_update_10007() {
   }
   return t('Added embed_buttons/* ignore pattern.');
 }
+
+/**
+ * Implements hook_uninstall().
+ */
+function file_adoption_uninstall() {
+  $db = \Drupal::database();
+  if ($db->schema()->tableExists('file_adoption_orphans')) {
+    $db->schema()->dropTable('file_adoption_orphans');
+  }
+
+  \Drupal::configFactory()->getEditable('file_adoption.settings')->delete();
+}


### PR DESCRIPTION
## Summary
- drop `file_adoption_orphans` table and delete settings on uninstall
- document uninstall behavior

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: `No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_686cebf806e88331ad34b5557bc6f5b1