### PR TITLE
Add monthly/yearly cron options and disable verbose logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ The configuration form offers the following options:
   preventing loops or slowdowns caused by symlinks.
   Symlinks discovered during scanning are still listed under the "Symlinks"
 - **Cron Frequency** – How often cron should run file adoption tasks. Options
-  include every cron run, hourly, daily, or weekly.
+  include every cron run, hourly, daily, weekly, monthly, or yearly.
 - **Verbose Logging** – When enabled, additional debug information is written to
-  the log during scans and adoption. This is on by default. Adoption success
+  the log during scans and adoption. This is off by default. Adoption success
   messages are only recorded when verbose logging is enabled. When enabled,
   each directory encountered during cron scans is also logged.
 

--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -12,5 +12,5 @@ ignore_patterns: |
 enable_adoption: false
 items_per_run: 20
 ignore_symlinks: false
-cron_frequency: daily
-verbose_logging: true
+cron_frequency: yearly
+verbose_logging: false

--- a/file_adoption.module
+++ b/file_adoption.module
@@ -11,16 +11,18 @@
 function file_adoption_cron() {
   $config = \Drupal::config('file_adoption.settings');
   $state = \Drupal::state();
-  $frequency = $config->get('cron_frequency') ?: 'daily';
+  $frequency = $config->get('cron_frequency') ?: 'yearly';
   $intervals = [
     'every' => 0,
     'hourly' => 3600,
     'daily' => 86400,
     'weekly' => 604800,
+    'monthly' => 2592000,
+    'yearly' => 31536000,
   ];
   $last = (int) $state->get('file_adoption.last_cron', 0);
   $now = time();
-  $interval = $intervals[$frequency] ?? 86400;
+  $interval = $intervals[$frequency] ?? 31536000;
   if ($last && ($now - $last) < $interval) {
     return;
   }

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -112,12 +112,14 @@ class FileAdoptionForm extends ConfigFormBase {
       'hourly' => $this->t('Hourly'),
       'daily' => $this->t('Daily'),
       'weekly' => $this->t('Weekly'),
+      'monthly' => $this->t('Monthly'),
+      'yearly' => $this->t('Yearly'),
     ];
     $form['cron_frequency'] = [
       '#type' => 'select',
       '#title' => $this->t('Cron frequency'),
       '#options' => $options,
-      '#default_value' => $config->get('cron_frequency') ?: 'daily',
+      '#default_value' => $config->get('cron_frequency') ?: 'yearly',
     ];
 
     $form['verbose_logging'] = [

--- a/tests/src/Kernel/FileAdoptionCronTest.php
+++ b/tests/src/Kernel/FileAdoptionCronTest.php
@@ -141,4 +141,74 @@ class FileAdoptionCronTest extends KernelTestBase {
     $this->assertEquals(1, $count);
   }
 
+  /**
+   * Ensures the monthly cron frequency is respected.
+   */
+  public function testCronFrequencyMonthly() {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save();
+
+    file_put_contents("$public/file.txt", 'x');
+
+    $this->config('file_adoption.settings')
+      ->set('enable_adoption', FALSE)
+      ->set('cron_frequency', 'monthly')
+      ->save();
+
+    \Drupal::state()->set('file_adoption.last_cron', REQUEST_TIME);
+
+    file_adoption_cron();
+    $count = $this->container->get('database')
+      ->select('file_adoption_orphans')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(0, $count);
+
+    \Drupal::state()->set('file_adoption.last_cron', REQUEST_TIME - 2592000 - 1);
+
+    file_adoption_cron();
+    $count = $this->container->get('database')
+      ->select('file_adoption_orphans')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(1, $count);
+  }
+
+  /**
+   * Ensures the yearly cron frequency is respected.
+   */
+  public function testCronFrequencyYearly() {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save();
+
+    file_put_contents("$public/file.txt", 'x');
+
+    $this->config('file_adoption.settings')
+      ->set('enable_adoption', FALSE)
+      ->set('cron_frequency', 'yearly')
+      ->save();
+
+    \Drupal::state()->set('file_adoption.last_cron', REQUEST_TIME);
+
+    file_adoption_cron();
+    $count = $this->container->get('database')
+      ->select('file_adoption_orphans')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(0, $count);
+
+    \Drupal::state()->set('file_adoption.last_cron', REQUEST_TIME - 31536000 - 1);
+
+    file_adoption_cron();
+    $count = $this->container->get('database')
+      ->select('file_adoption_orphans')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(1, $count);
+  }
+
 }


### PR DESCRIPTION
## Summary
- disable verbose logging by default
- add monthly and yearly cron frequencies
- set yearly as the default frequency
- document new options in the README
- test new cron frequencies

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption/tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686d3e2e245c8331b69ce228e2861ea1