### PR TITLE
Inject database connection in form

### DIFF
--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -31,7 +31,8 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form_state = new FormState();
     $form_object = new FileAdoptionForm(
-      $this->container->get('file_adoption.file_scanner')
+      $this->container->get('file_adoption.file_scanner'),
+      $this->container->get('database')
     );
     $form = $form_object->buildForm([], $form_state);
 
@@ -50,7 +51,8 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form_state = new FormState();
     $form_object = new FileAdoptionForm(
-      $this->container->get('file_adoption.file_scanner')
+      $this->container->get('file_adoption.file_scanner'),
+      $this->container->get('database')
     );
     $form = $form_object->buildForm([], $form_state);
 
@@ -79,7 +81,8 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $form_state = new FormState();
     $form_object = new FileAdoptionForm(
-      $this->container->get('file_adoption.file_scanner')
+      $this->container->get('file_adoption.file_scanner'),
+      $this->container->get('database')
     );
 
     $form = $form_object->buildForm([], $form_state);


### PR DESCRIPTION
## Summary
- inject the database service into `FileAdoptionForm`
- update tests to match the new constructor

## Testing
- `php -l src/Form/FileAdoptionForm.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4643c674833182e1950a7dba0d67