### PR TITLE
Add strict types and type hints

### DIFF
--- a/file_adoption.install
+++ b/file_adoption.install
@@ -1,9 +1,10 @@
 <?php
+declare(strict_types=1);
 
 /**
  * Implements hook_update_N().
  */
-function file_adoption_update_10001() {
+function file_adoption_update_10001(): string {
   $config = \Drupal::configFactory()->getEditable('file_adoption.settings');
   if ($config->get('items_per_run') === NULL) {
     $config->set('items_per_run', 20)->save();
@@ -14,7 +15,7 @@ function file_adoption_update_10001() {
 /**
  * Implements hook_schema().
  */
-function file_adoption_schema() {
+function file_adoption_schema(): array {
   $schema['file_adoption_orphans'] = [
     'description' => 'Orphan file URIs discovered during scans.',
     'fields' => [
@@ -53,7 +54,7 @@ function file_adoption_schema() {
 /**
  * Creates the orphan tracking table on update.
  */
-function file_adoption_update_10002() {
+function file_adoption_update_10002(): string {
   $schema = file_adoption_schema()['file_adoption_orphans'];
   $db = \Drupal::database();
   if (!$db->schema()->tableExists('file_adoption_orphans')) {
@@ -65,7 +66,7 @@ function file_adoption_update_10002() {
 /**
  * Adds the ignore_symlinks setting.
  */
-function file_adoption_update_10003() {
+function file_adoption_update_10003(): string {
   $config = \Drupal::configFactory()->getEditable('file_adoption.settings');
   if ($config->get('ignore_symlinks') === NULL) {
     $config->set('ignore_symlinks', FALSE)->save();
@@ -76,7 +77,7 @@ function file_adoption_update_10003() {
 /**
  * Adds the cron_frequency setting.
  */
-function file_adoption_update_10004() {
+function file_adoption_update_10004(): string {
   $config = \Drupal::configFactory()->getEditable('file_adoption.settings');
   if ($config->get('cron_frequency') === NULL) {
     $config->set('cron_frequency', 'daily')->save();
@@ -87,7 +88,7 @@ function file_adoption_update_10004() {
 /**
  * Adds the verbose_logging setting.
  */
-function file_adoption_update_10005() {
+function file_adoption_update_10005(): string {
   $config = \Drupal::configFactory()->getEditable('file_adoption.settings');
   if ($config->get('verbose_logging') === NULL) {
     $config->set('verbose_logging', TRUE)->save();
@@ -98,7 +99,7 @@ function file_adoption_update_10005() {
 /**
  * Appends asset_injector/* to ignore_patterns by default.
  */
-function file_adoption_update_10006() {
+function file_adoption_update_10006(): string {
   $config = \Drupal::configFactory()->getEditable('file_adoption.settings');
   $patterns = $config->get('ignore_patterns') ?: '';
   $list = preg_split("/(\r\n|\n|\r|,)/", $patterns);
@@ -117,7 +118,7 @@ function file_adoption_update_10006() {
 /**
  * Appends embed_buttons/* to ignore_patterns by default.
  */
-function file_adoption_update_10007() {
+function file_adoption_update_10007(): string {
   $config = \Drupal::configFactory()->getEditable('file_adoption.settings');
   $patterns = $config->get('ignore_patterns') ?: '';
   $list = preg_split("/(\r\n|\n|\r|,)/", $patterns);
@@ -136,7 +137,7 @@ function file_adoption_update_10007() {
 /**
  * Implements hook_uninstall().
  */
-function file_adoption_uninstall() {
+function file_adoption_uninstall(): void {
   $db = \Drupal::database();
   if ($db->schema()->tableExists('file_adoption_orphans')) {
     $db->schema()->dropTable('file_adoption_orphans');

--- a/file_adoption.module
+++ b/file_adoption.module
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * @file
@@ -8,7 +9,7 @@
 /**
  * Implements hook_cron().
  */
-function file_adoption_cron() {
+function file_adoption_cron(): void {
   $config = \Drupal::config('file_adoption.settings');
   $state = \Drupal::state();
   $frequency = $config->get('cron_frequency') ?: 'yearly';

--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Drupal\file_adoption;
 
@@ -18,28 +19,28 @@ class FileScanner {
    *
    * @var \Drupal\Core\File\FileSystemInterface
    */
-  protected $fileSystem;
+  protected FileSystemInterface $fileSystem;
 
   /**
    * The database connection.
    *
    * @var \Drupal\Core\Database\Connection
    */
-  protected $database;
+  protected Connection $database;
 
   /**
    * The configuration factory.
    *
    * @var \Drupal\Core\Config\ConfigFactoryInterface
    */
-  protected $configFactory;
+  protected ConfigFactoryInterface $configFactory;
 
   /**
    * The logger channel for the file_adoption module.
    *
    * @var \Psr\Log\LoggerInterface
    */
-  protected $logger;
+  protected LoggerInterface $logger;
 
 
   /**
@@ -47,21 +48,21 @@ class FileScanner {
    *
    * @var array
    */
-  protected $managedUris = [];
+  protected array $managedUris = [];
 
   /**
    * Indicates whether managed URIs have been loaded.
    *
    * @var bool
    */
-  protected $managedLoaded = FALSE;
+  protected bool $managedLoaded = FALSE;
 
   /**
    * Table name used to persist discovered orphan files.
    *
    * @var string
    */
-  protected $orphanTable = 'file_adoption_orphans';
+  protected string $orphanTable = 'file_adoption_orphans';
 
   /**
    * Constructs a FileScanner service object.
@@ -89,7 +90,7 @@ class FileScanner {
    * @return string[]
    *   An array of ignore pattern strings.
    */
-  public function getIgnorePatterns() {
+  public function getIgnorePatterns(): array {
     $config = $this->configFactory->get('file_adoption.settings');
     $raw_patterns = $config->get('ignore_patterns');
     if (empty($raw_patterns)) {
@@ -260,7 +261,7 @@ class FileScanner {
    * @return array
    *   An associative array with the keys 'files', 'orphans' and 'adopted'.
    */
-  public function scanAndProcess(bool $adopt = TRUE, int $limit = 0) {
+  public function scanAndProcess(bool $adopt = TRUE, int $limit = 0): array {
     $counts = ['files' => 0, 'orphans' => 0, 'adopted' => 0];
     $patterns = $this->getIgnorePatterns();
     $settings = $this->configFactory->get('file_adoption.settings');
@@ -314,7 +315,7 @@ class FileScanner {
    * @return array
    *   Associative array with keys 'files', 'orphans' and 'to_manage'.
    */
-  public function scanWithLists(int $limit = 500) {
+  public function scanWithLists(int $limit = 500): array {
     $results = ['files' => 0, 'orphans' => 0, 'to_manage' => []];
     $patterns = $this->getIgnorePatterns();
     $settings = $this->configFactory->get('file_adoption.settings');
@@ -405,7 +406,7 @@ class FileScanner {
    * @return int
    *   The number of newly created items.
    */
-  public function adoptFiles(array $file_uris) {
+  public function adoptFiles(array $file_uris): int {
     $this->loadManagedUris();
     $count = 0;
     foreach ($file_uris as $uri) {
@@ -427,7 +428,7 @@ class FileScanner {
    * @return bool
    *   TRUE if a new file entity was created, FALSE otherwise.
    */
-  public function adoptFile(string $uri) {
+  public function adoptFile(string $uri): bool {
 
     $uri = $this->canonicalizeUri($uri);
     $settings = $this->configFactory->get('file_adoption.settings');

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Drupal\file_adoption\Form;
 
@@ -20,7 +21,7 @@ class FileAdoptionForm extends ConfigFormBase {
    *
    * @var \Drupal\file_adoption\FileScanner
   */
-  protected $fileScanner;
+  protected FileScanner $fileScanner;
 
   /**
    * The database connection.
@@ -48,7 +49,7 @@ class FileAdoptionForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): static {
     return new static(
       $container->get('file_adoption.file_scanner'),
       $container->get('database')
@@ -58,21 +59,21 @@ class FileAdoptionForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
+  public function getFormId(): string {
     return 'file_adoption_settings_form';
   }
 
   /**
    * {@inheritdoc}
    */
-  protected function getEditableConfigNames() {
+  protected function getEditableConfigNames(): array {
     return ['file_adoption.settings'];
   }
 
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state) {
+  public function buildForm(array $form, FormStateInterface $form_state): array {
     $config = $this->config('file_adoption.settings');
 
     $table_count = (int) $this->database->select('file_adoption_orphans')
@@ -253,7 +254,7 @@ class FileAdoptionForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submitForm(array &$form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
     $items_per_run = (int) $form_state->getValue('items_per_run');
     if ($items_per_run <= 0) {
       $items_per_run = 20;

--- a/tests/src/Kernel/FileAdoptionCronTest.php
+++ b/tests/src/Kernel/FileAdoptionCronTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Drupal\Tests\file_adoption\Kernel;
 

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Drupal\Tests\file_adoption\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;

--- a/tests/src/Kernel/FileScannerTest.php
+++ b/tests/src/Kernel/FileScannerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Drupal\Tests\file_adoption\Kernel;
 


### PR DESCRIPTION
## Summary
- enforce strict types across PHP files
- type class properties
- add return type hints for methods

## Testing
- `php -l file_adoption.module`
- `php -l file_adoption.install`
- `php -l src/FileScanner.php`
- `php -l src/Form/FileAdoptionForm.php`
- `php -l tests/src/Kernel/FileAdoptionCronTest.php`
- `php -l tests/src/Kernel/FileAdoptionFormTest.php`
- `php -l tests/src/Kernel/FileScannerTest.php`

------
https://chatgpt.com/codex/tasks/task_e_686d476fa5848331ac08ebe676a02e34