### PR TITLE
Add RecordOrphans kernel test

### DIFF
--- a/tests/src/Kernel/RecordOrphansTest.php
+++ b/tests/src/Kernel/RecordOrphansTest.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace Drupal\Tests\file_adoption\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\file_adoption\FileScanner;
+
+/**
+ * Tests the recordOrphans() method.
+ *
+ * @group file_adoption
+ */
+class RecordOrphansTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'file', 'file_adoption'];
+
+  /**
+   * Ensures orphan recording respects the limit.
+   */
+  public function testRecordOrphansLimit() {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save();
+
+    file_put_contents("$public/one.txt", '1');
+    file_put_contents("$public/two.txt", '2');
+    file_put_contents("$public/three.txt", '3');
+
+    /** @var FileScanner $scanner */
+    $scanner = $this->container->get('file_adoption.file_scanner');
+
+    $scanner->recordOrphans(2);
+
+    $count = $this->container->get('database')
+      ->select('file_adoption_orphans')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+
+    $this->assertEquals(2, $count);
+  }
+
+}
+


### PR DESCRIPTION
## Summary
- add RecordOrphansTest to check recordOrphans() with limit

## Testing
- `phpunit -c core modules/custom/file_adoption/tests/src/Kernel/RecordOrphansTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d48c319908331b9af68a4076b5cfa