### PR TITLE
Improve cron status messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ Changes are stored in `file_adoption.settings`.
 
 Scanning occurs exclusively during cron runs. The `Cron Frequency` setting
 controls how often `hook_cron()` invokes the `FileScanner` service. Each run
-builds the `file_adoption_orphans` table which caches any discovered orphans.
-When **Enable Adoption** is active the same run will also register those files
-as entities. The configuration page merely reads from this table, so the results
-shown there reflect the last cron execution rather than a fresh scan.
+records its totals to state so the configuration page can report the last
+execution. When **Enable Adoption** is disabled the run also populates the
+`file_adoption_orphans` table with any discovered orphans. When adoption is
+enabled, files are registered immediately and the table remains empty.
 
 ## Running Tests
 

--- a/file_adoption.module
+++ b/file_adoption.module
@@ -33,9 +33,11 @@ function file_adoption_cron(): void {
   $limit = (int) $config->get('items_per_run');
 
   if ($config->get('enable_adoption')) {
-    $scanner->scanAndProcess(TRUE, $limit);
+    $results = $scanner->scanAndProcess(TRUE, $limit);
   }
   else {
-    $scanner->recordOrphans($limit);
+    $results = $scanner->recordOrphans($limit);
   }
+
+  $state->set('file_adoption.last_results', $results);
 }

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -33,7 +33,8 @@ class FileAdoptionFormTest extends KernelTestBase {
     $form_state = new FormState();
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('database')
+      $this->container->get('database'),
+      $this->container->get('state')
     );
     $form = $form_object->buildForm([], $form_state);
 
@@ -53,7 +54,8 @@ class FileAdoptionFormTest extends KernelTestBase {
     $form_state = new FormState();
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('database')
+      $this->container->get('database'),
+      $this->container->get('state')
     );
     $form = $form_object->buildForm([], $form_state);
 
@@ -83,7 +85,8 @@ class FileAdoptionFormTest extends KernelTestBase {
     $form_state = new FormState();
     $form_object = new FileAdoptionForm(
       $this->container->get('file_adoption.file_scanner'),
-      $this->container->get('database')
+      $this->container->get('database'),
+      $this->container->get('state')
     );
 
     $form = $form_object->buildForm([], $form_state);


### PR DESCRIPTION
## Summary
- store results of cron scans to state
- show last adoption info on config page when orphan table is empty
- update kernel tests for new constructor
- document cron result tracking

## Testing
- `php` (fail: command not found)


------
https://chatgpt.com/codex/tasks/task_e_686d530f2dc883319fdd66ac2afb941e