### PR TITLE
Add oembed_thumbnails ignore pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The configuration form offers the following options:
   `public://`) that should be skipped when scanning. The default configuration
   skips directories such as `css/*`, `js/*`, `private/*`, `webforms/*`,
   `config_*`, `media-icons/*`, `php/*`, `styles/*`, `asset_injector/*`,
-  and `embed_buttons/*`.
+  `embed_buttons/*`, and `oembed_thumbnails/*`.
 - **Enable Adoption** – When checked, cron will automatically adopt orphaned
   files using the configured settings.
 - **Items per cron run** – Maximum number of files processed and displayed per

--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -9,6 +9,7 @@ ignore_patterns: |
   styles/*
   asset_injector/*
   embed_buttons/*
+  oembed_thumbnails/*
 enable_adoption: false
 items_per_run: 20
 ignore_symlinks: false

--- a/file_adoption.install
+++ b/file_adoption.install
@@ -135,6 +135,25 @@ function file_adoption_update_10007(): string {
 }
 
 /**
+ * Appends oembed_thumbnails/* to ignore_patterns by default.
+ */
+function file_adoption_update_10008(): string {
+  $config = \Drupal::configFactory()->getEditable('file_adoption.settings');
+  $patterns = $config->get('ignore_patterns') ?: '';
+  $list = preg_split("/(\r\n|\n|\r|,)/", $patterns);
+  $list = array_map('trim', $list);
+  if (!in_array('oembed_thumbnails/*', $list, TRUE)) {
+    $patterns = trim($patterns);
+    if ($patterns !== '') {
+      $patterns .= "\n";
+    }
+    $patterns .= 'oembed_thumbnails/*';
+    $config->set('ignore_patterns', $patterns)->save();
+  }
+  return t('Added oembed_thumbnails/* ignore pattern.');
+}
+
+/**
  * Implements hook_uninstall().
  */
 function file_adoption_uninstall(): void {


### PR DESCRIPTION
## Summary
- add `oembed_thumbnails/*` as an ignore pattern
- mention the new pattern in the README
- provide an update hook to append the pattern for existing installs

## Testing
- `php -l file_adoption.install`
- `php -l src/FileScanner.php`
- `phpunit -c ./phpunit.xml --testsuite unit` *(fails: Could not read "./phpunit.xml")*

------
https://chatgpt.com/codex/tasks/task_e_686d6020cbec83318cfb05328ad3ee05