### PR TITLE
Mirror filesystem in DB for fast lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ records its totals to state so the configuration page can report the last
 execution. When **Enable Adoption** is disabled the run also populates the
 `file_adoption_orphans` table with any discovered orphans. When adoption is
 enabled, files are registered immediately and the table remains empty.
+Every cron run also rebuilds the `file_adoption_index` table, which lists all
+files the application can access for fast lookups.
 
 ## Running Tests
 
@@ -70,5 +72,6 @@ the `FileScanner` service and the configuration form.
 
 ## Uninstall
 
-Uninstalling the module removes all of its configuration and drops the
-`file_adoption_orphans` table so no leftover data remains.
+Uninstalling the module removes all configuration and drops the
+`file_adoption_orphans` and `file_adoption_index` tables so no leftover data
+remains.

--- a/file_adoption.install
+++ b/file_adoption.install
@@ -48,6 +48,38 @@ function file_adoption_schema(): array {
     ],
   ];
 
+  $schema['file_adoption_index'] = [
+    'description' => 'Normalized list of files discovered during scans.',
+    'fields' => [
+      'id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'description' => 'Primary identifier.',
+      ],
+      'uri' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'description' => 'File URI.',
+      ],
+      'timestamp' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Time the file was indexed.',
+      ],
+    ],
+    'primary key' => ['id'],
+    'unique keys' => [
+      'uri' => ['uri'],
+    ],
+    'indexes' => [
+      'timestamp' => ['timestamp'],
+    ],
+  ];
+
   return $schema;
 }
 
@@ -154,12 +186,27 @@ function file_adoption_update_10008(): string {
 }
 
 /**
+ * Creates the file index table.
+ */
+function file_adoption_update_10009(): string {
+  $schema = file_adoption_schema()['file_adoption_index'];
+  $db = \Drupal::database();
+  if (!$db->schema()->tableExists('file_adoption_index')) {
+    $db->schema()->createTable('file_adoption_index', $schema);
+  }
+  return (string) t('Added file_adoption_index table.');
+}
+
+/**
  * Implements hook_uninstall().
  */
 function file_adoption_uninstall(): void {
   $db = \Drupal::database();
   if ($db->schema()->tableExists('file_adoption_orphans')) {
     $db->schema()->dropTable('file_adoption_orphans');
+  }
+  if ($db->schema()->tableExists('file_adoption_index')) {
+    $db->schema()->dropTable('file_adoption_index');
   }
 
   \Drupal::configFactory()->getEditable('file_adoption.settings')->delete();

--- a/file_adoption.module
+++ b/file_adoption.module
@@ -39,5 +39,44 @@ function file_adoption_cron(): void {
     $results = $scanner->recordOrphans($limit);
   }
 
+  // Refresh the full file index.
+  $scanner->buildIndex();
+
   $state->set('file_adoption.last_results', $results);
+}
+
+/**
+ * Implements hook_entity_insert().
+ */
+function file_adoption_entity_insert(\Drupal\Core\Entity\EntityInterface $entity): void {
+  if ($entity->getEntityTypeId() !== 'file') {
+    return;
+  }
+  $uri = $entity->getFileUri();
+  if (str_starts_with($uri, 'public://')) {
+    $uri = 'public://' . ltrim(substr($uri, 9), '/');
+  }
+  \Drupal::database()->merge('file_adoption_index')
+    ->key('uri', $uri)
+    ->fields([
+      'uri' => $uri,
+      'timestamp' => time(),
+    ])
+    ->execute();
+}
+
+/**
+ * Implements hook_entity_delete().
+ */
+function file_adoption_entity_delete(\Drupal\Core\Entity\EntityInterface $entity): void {
+  if ($entity->getEntityTypeId() !== 'file') {
+    return;
+  }
+  $uri = $entity->getFileUri();
+  if (str_starts_with($uri, 'public://')) {
+    $uri = 'public://' . ltrim(substr($uri, 9), '/');
+  }
+  \Drupal::database()->delete('file_adoption_index')
+    ->condition('uri', $uri)
+    ->execute();
 }


### PR DESCRIPTION
## Summary
- add `file_adoption_index` table schema and update hook
- rebuild the index table on cron runs
- track file entity inserts/deletes to keep the index in sync
- expose new methods in `FileScanner`
- document file index table

## Testing
- `phpunit --version` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e8d1df95483318bc8c5f08e18b323