### PR TITLE
Update directories section with ignore patterns

### DIFF
--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -146,6 +146,9 @@ class FileAdoptionFormTest extends KernelTestBase {
     $this->assertStringContainsString('skip.log', $markup);
     $this->assertStringContainsString('tmp2/', $markup);
     $this->assertStringContainsString('ignored', $markup);
+
+    $pattern_markup = $form['directories']['patterns']['#markup'];
+    $this->assertStringContainsString('*.log', $pattern_markup);
   }
 
   /**


### PR DESCRIPTION
## Summary
- mark directories ignored by pattern when building form
- display ignored file patterns in the same directories section
- update test to check for patterns display

## Testing
- `phpunit -c phpunit.xml` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6870138880cc83318874afa282c6adf2