### PR TITLE
Mark directories ignored when any contained file matches pattern

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -153,7 +153,9 @@ class FileAdoptionForm extends ConfigFormBase {
           break;
         }
       }
-      $info['ignored'] = $matches || ($info['total'] > 0 && $info['ignored_count'] === $info['total']);
+      // Mark the directory as ignored if any ignore pattern matches the
+      // directory itself or any file inside it.
+      $info['ignored'] = $matches || $info['ignored_count'] > 0;
     }
     unset($info);
 


### PR DESCRIPTION
## Summary
- ensure directory entries are marked ignored when any file or pattern matches

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870163d500483318e2560c0f4999f26