### PR TITLE
Refresh orphan list from file index

### DIFF
--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -86,6 +86,10 @@ class FileAdoptionForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state): array {
     $config = $this->config('file_adoption.settings');
 
+    // Refresh the orphan table from the index so the form always reflects
+    // the latest ignore pattern settings.
+    $this->fileScanner->rebuildOrphansFromIndex();
+
     $table_count = (int) $this->database->select('file_adoption_orphans')
       ->countQuery()
       ->execute()


### PR DESCRIPTION
## Summary
- add FileScanner::rebuildOrphansFromIndex
- call rebuild when building the FileAdoptionForm
- test that removing ignore patterns immediately updates the orphan list

## Testing
- `phpunit tests/src/Kernel/FileAdoptionFormTest.php` *(fails: Class "Drupal\KernelTests\KernelTestBase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_687029f420408331ad84ccf952013c0c