### PR TITLE
Add development setup docs and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: composer
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -67,6 +67,39 @@ enabled, files are registered immediately and the table remains empty.
 Every cron run also rebuilds the `file_adoption_index` table, which lists all
 files the application can access for fast lookups.
 
+## Development setup
+
+This module targets **PHP 8.1** or newer. You will also need [Composer](https://getcomposer.org/) to install development dependencies.
+
+### Install PHP
+
+Example for Debian/Ubuntu based systems:
+
+```bash
+sudo apt update
+sudo apt install php8.1 php8.1-cli php8.1-xml php8.1-mbstring
+```
+
+macOS users can install PHP via [Homebrew](https://brew.sh/):
+
+```bash
+brew install php
+```
+
+### Install Composer
+
+```bash
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+php -r "unlink('composer-setup.php');"
+```
+
+After Composer is available, install this module's dependencies:
+
+```bash
+composer install
+```
+
 ## Running Tests
 
 These tests rely on Drupal's core testing environment. Make sure your Drupal


### PR DESCRIPTION
## Summary
- add Development setup section in README with PHP and Composer install steps
- add GitHub Actions CI workflow to run phpunit

## Testing
- `apt-get update`
- `apt-get install -y php`
- `php -v`
- `php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" ...` *(fails: Network is unreachable)*
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68702bc865348331baec219cac15188b