### PR TITLE
Implement case-insensitive ignore patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ The configuration form offers the following options:
   `public://`) that should be skipped when scanning. The default configuration
   skips directories such as `css/*`, `js/*`, `private/*`, `webforms/*`,
   `config_*`, `media-icons/*`, `php/*`, `styles/*`, `asset_injector/*`,
-  `embed_buttons/*`, and `oembed_thumbnails/*`.
+  `embed_buttons/*`, and `oembed_thumbnails/*`. Pattern matching is
+  case-insensitive.
 - **Enable Adoption** – When checked, cron will automatically adopt orphaned
   files using the configured settings.
 - **Items per cron run** – Maximum number of files processed and displayed per

--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -148,7 +148,7 @@ class FileScanner {
    */
   private function isIgnored(string $relative, array $patterns, bool $verbose): bool {
     foreach ($patterns as $pattern) {
-      if ($pattern !== '' && fnmatch($pattern, $relative)) {
+      if ($pattern !== '' && fnmatch($pattern, $relative, FNM_CASEFOLD)) {
         if ($verbose) {
           $this->logger->debug('Ignored file @file by pattern @pattern', ['@file' => $relative, '@pattern' => $pattern]);
         }

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -168,7 +168,7 @@ class FileAdoptionForm extends ConfigFormBase {
       $matches = FALSE;
       foreach ($dir_patterns as $pattern) {
         $check = rtrim($pattern, '/') . '/';
-        if ($pattern !== '' && fnmatch($check, $path)) {
+        if ($pattern !== '' && fnmatch($check, $path, FNM_CASEFOLD)) {
           $matches = TRUE;
           break;
         }
@@ -289,7 +289,7 @@ class FileAdoptionForm extends ConfigFormBase {
           $relative = str_starts_with($uri, 'public://') ? substr($uri, 9) : $uri;
           $ignored = FALSE;
           foreach ($patterns as $pattern) {
-            if ($pattern !== '' && fnmatch($pattern, $relative)) {
+            if ($pattern !== '' && fnmatch($pattern, $relative, FNM_CASEFOLD)) {
               $ignored = TRUE;
               break;
             }

--- a/tests/src/Kernel/FileScannerTest.php
+++ b/tests/src/Kernel/FileScannerTest.php
@@ -323,4 +323,24 @@ class FileScannerTest extends KernelTestBase {
     $this->assertEquals(0, $records['public://skip.log']->managed);
   }
 
+  /**
+   * Verifies ignore patterns are case-insensitive.
+   */
+  public function testIgnorePatternsCaseInsensitive() {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save();
+
+    file_put_contents("$public/TestFile.txt", 'x');
+    file_put_contents("$public/keep.txt", 'y');
+
+    $this->config('file_adoption.settings')->set('ignore_patterns', '*test*')->save();
+
+    /** @var FileScanner $scanner */
+    $scanner = $this->container->get('file_adoption.file_scanner');
+
+    $results = $scanner->scanWithLists();
+    $this->assertEquals(1, $results['files']);
+    $this->assertEquals(['public://keep.txt'], $results['to_manage']);
+  }
+
 }


### PR DESCRIPTION
## Summary
- match ignore patterns without regard to case
- apply FNM_CASEFOLD in the form when displaying directories
- test that `*test*` ignores files in any case
- document that ignore pattern matching is case-insensitive

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption/tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68702cc1063483319dc16d4d9ea338e3