### PR TITLE
Fix orphan recording limit logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ The configuration form offers the following options:
   case-insensitive.
 - **Enable Adoption** – When checked, cron will automatically adopt orphaned
   files using the configured settings.
-- **Items per cron run** – Maximum number of files processed and displayed per
-  scan or cron run. Defaults to 20.
+- **Items per cron run** – Maximum number of files adopted or displayed per
+  scan or cron run. All discovered orphans are saved regardless of this
+  limit. Defaults to 20.
 - **Ignore Symlinks** – When enabled, symbolic links are skipped during scanning,
   preventing loops or slowdowns caused by symlinks.
   Symlinks discovered during scanning are still listed under the "Symlinks"
@@ -63,8 +64,9 @@ Scanning occurs exclusively during cron runs. The `Cron Frequency` setting
 controls how often `hook_cron()` invokes the `FileScanner` service. Each run
 records its totals to state so the configuration page can report the last
 execution. When **Enable Adoption** is disabled the run also populates the
-`file_adoption_orphans` table with any discovered orphans. When adoption is
-enabled, files are registered immediately and the table remains empty.
+`file_adoption_orphans` table with any discovered orphans. All orphans remain
+recorded in this table regardless of the item limit. When adoption is enabled,
+files are registered immediately and the table remains empty.
 Every cron run also rebuilds the `file_adoption_index` table, which lists all
 files the application can access for fast lookups.
 

--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -419,7 +419,10 @@ class FileScanner {
    * orphan table before scanning and stops once the limit is reached.
    *
    * @param int $limit
-   *   Maximum number of orphans to record.
+   *   (optional) Parameter retained for backward compatibility. The scan no
+   *   longer stops when this limit is reached. All discovered orphans are
+   *   recorded and the limit should instead be enforced when adopting or
+   *   displaying results.
    *
    * @return array
    *   Counts for 'files' and 'orphans'.
@@ -442,9 +445,6 @@ class FileScanner {
     }
 
     foreach ($this->iterateFiles($public_realpath, $ignore_symlinks, $patterns, $verbose) as $uri) {
-      if ($limit > 0 && $results['orphans'] >= $limit) {
-        break;
-      }
 
       $results['files']++;
 

--- a/tests/src/Kernel/RecordOrphansTest.php
+++ b/tests/src/Kernel/RecordOrphansTest.php
@@ -19,7 +19,7 @@ class RecordOrphansTest extends KernelTestBase {
   protected static $modules = ['system', 'user', 'file', 'file_adoption'];
 
   /**
-   * Ensures orphan recording respects the limit.
+   * Ensures recordOrphans scans all files even when a limit is provided.
    */
   public function testRecordOrphansLimit() {
     $public = $this->container->get('file_system')->getTempDirectory();
@@ -40,7 +40,7 @@ class RecordOrphansTest extends KernelTestBase {
       ->execute()
       ->fetchField();
 
-    $this->assertEquals(2, $count);
+    $this->assertEquals(3, $count);
   }
 
   /**


### PR DESCRIPTION
## Summary
- record all orphans instead of stopping when the limit is reached
- update test for new behaviour
- document that the item limit only affects adoption and display

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68702dc9e04c83319208fb475fd42640