### PR TITLE
Support managed flag maintenance

### DIFF
--- a/file_adoption.module
+++ b/file_adoption.module
@@ -73,6 +73,7 @@ function file_adoption_entity_insert(\Drupal\Core\Entity\EntityInterface $entity
       'uri' => $uri,
       'timestamp' => time(),
       'ignored' => $ignored ? 1 : 0,
+      'managed' => 1,
     ])
     ->execute();
 }
@@ -88,7 +89,24 @@ function file_adoption_entity_delete(\Drupal\Core\Entity\EntityInterface $entity
   if (str_starts_with($uri, 'public://')) {
     $uri = 'public://' . ltrim(substr($uri, 9), '/');
   }
-  \Drupal::database()->delete('file_adoption_index')
-    ->condition('uri', $uri)
+  /** @var \Drupal\file_adoption\FileScanner $scanner */
+  $scanner = \Drupal::service('file_adoption.file_scanner');
+  $patterns = $scanner->getIgnorePatterns();
+  $relative = str_starts_with($uri, 'public://') ? substr($uri, 9) : $uri;
+  $ignored = FALSE;
+  foreach ($patterns as $pattern) {
+    if ($pattern !== '' && fnmatch($pattern, $relative)) {
+      $ignored = TRUE;
+      break;
+    }
+  }
+  \Drupal::database()->merge('file_adoption_index')
+    ->key('uri', $uri)
+    ->fields([
+      'uri' => $uri,
+      'timestamp' => time(),
+      'ignored' => $ignored ? 1 : 0,
+      'managed' => 0,
+    ])
     ->execute();
 }

--- a/tests/src/Kernel/FileIndexHooksTest.php
+++ b/tests/src/Kernel/FileIndexHooksTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+namespace Drupal\Tests\file_adoption\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\file\Entity\File;
+
+/**
+ * Tests that entity hooks maintain the managed flag in the index table.
+ *
+ * @group file_adoption
+ */
+class FileIndexHooksTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'file', 'file_adoption'];
+
+  /**
+   * Verifies insert and delete hooks update the managed flag.
+   */
+  public function testManagedFlagUpdates() {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save();
+
+    // Create the actual file.
+    file_put_contents("$public/example.txt", 'x');
+
+    // Saving a file entity triggers hook_entity_insert().
+    $file = File::create([
+      'uri' => 'public://example.txt',
+      'filename' => 'example.txt',
+      'status' => 1,
+      'uid' => 0,
+    ]);
+    $file->save();
+
+    $record = $this->container->get('database')
+      ->select('file_adoption_index', 'fi')
+      ->fields('fi', ['managed'])
+      ->condition('uri', 'public://example.txt')
+      ->execute()
+      ->fetchObject();
+    $this->assertNotEmpty($record);
+    $this->assertEquals(1, $record->managed);
+
+    // Deleting the entity should set managed to 0 but keep the row.
+    $file->delete();
+
+    $record = $this->container->get('database')
+      ->select('file_adoption_index', 'fi')
+      ->fields('fi', ['managed'])
+      ->condition('uri', 'public://example.txt')
+      ->execute()
+      ->fetchObject();
+    $this->assertNotEmpty($record);
+    $this->assertEquals(0, $record->managed);
+  }
+}


### PR DESCRIPTION
## Summary
- keep file index up to date when file entities are inserted or deleted
- test entity hook behavior for managed flag

## Testing
- `php -l file_adoption.module`
- `php -l tests/src/Kernel/FileIndexHooksTest.php`
- `phpunit tests/src/Kernel/FileIndexHooksTest.php` *(fails: Class "Drupal\KernelTests\KernelTestBase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_687030408a9483318aed4c5f7d5367e6