### PR TITLE
Add Enable Adoption checkbox

### DIFF
--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -1,5 +1,6 @@
 items_per_run: 20
 scan_interval_hours: 24
+enable_adoption: false
 ignore_symlinks: true
 verbose_logging: false
 ignore_patterns: |

--- a/file_adoption.module
+++ b/file_adoption.module
@@ -25,7 +25,9 @@ function file_adoption_cron(): void {
     $state->set('file_adoption.last_full_scan', \Drupal::time()->getCurrentTime());
   }
 
-  $scanner->adoptUnmanaged((int) ($config->get('items_per_run') ?? 20));
+  if ($config->get('enable_adoption')) {
+    $scanner->adoptUnmanaged((int) ($config->get('items_per_run') ?? 20));
+  }
 }
 
 /**

--- a/file_adoption.settings.yml
+++ b/file_adoption.settings.yml
@@ -1,5 +1,6 @@
 items_per_run: 20
 scan_interval_hours: 24
+enable_adoption: false
 ignore_symlinks: true
 verbose_logging: false
 ignore_patterns: ''

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -48,6 +48,11 @@ class FileAdoptionForm extends FormBase implements ContainerInjectionInterface {
       '#default_value' => (int) ($config->get('scan_interval_hours') ?? 24),
       '#min'           => 1,
     ];
+    $form['settings']['enable_adoption'] = [
+      '#type'          => 'checkbox',
+      '#title'         => $this->t('Enable Adoption'),
+      '#default_value' => (bool) ($config->get('enable_adoption') ?? FALSE),
+    ];
     $form['settings']['items_per_run'] = [
       '#type'          => 'number',
       '#title'         => $this->t('Items per adoption batch'),
@@ -137,6 +142,7 @@ class FileAdoptionForm extends FormBase implements ContainerInjectionInterface {
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     $this->configFactory()->getEditable('file_adoption.settings')
       ->set('scan_interval_hours', (int) $form_state->getValue('scan_interval_hours'))
+      ->set('enable_adoption',    (bool) $form_state->getValue('enable_adoption'))
       ->set('items_per_run',       (int) $form_state->getValue('items_per_run'))
       ->set('ignore_patterns',     trim((string) $form_state->getValue('patterns')))
       ->save();


### PR DESCRIPTION
## Summary
- add `enable_adoption` setting to config
- allow enabling adoption from the admin form
- restrict cron adoption to run only when enabled

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption/tests || true` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68726ade87a08331a768c5d89f6590bf