### PR TITLE
Disable config schema validation in tests

### DIFF
--- a/tests/src/Kernel/DirectoryDepthTest.php
+++ b/tests/src/Kernel/DirectoryDepthTest.php
@@ -21,6 +21,11 @@ class DirectoryDepthTest extends KernelTestBase {
   protected static $modules = ['system', 'user', 'file', 'file_adoption'];
 
   /**
+   * Disable strict schema checks for configuration changes.
+   */
+  protected bool $strictConfigSchema = FALSE;
+
+  /**
    * Ensures directories deeper than the limit are omitted.
    */
   public function testDirectoryDepthLimit() {

--- a/tests/src/Kernel/FileAdoptionCronTest.php
+++ b/tests/src/Kernel/FileAdoptionCronTest.php
@@ -19,6 +19,11 @@ class FileAdoptionCronTest extends KernelTestBase {
   protected static $modules = ['system', 'user', 'file', 'file_adoption'];
 
   /**
+   * Disable strict schema checks for configuration changes.
+   */
+  protected bool $strictConfigSchema = FALSE;
+
+  /**
    * Tests that cron respects the item limit configuration.
    */
   public function testCronLimit() {

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -19,6 +19,11 @@ class FileAdoptionFormTest extends KernelTestBase {
   protected static $modules = ['system', 'user', 'file', 'file_adoption'];
 
   /**
+   * Disable strict schema checks for configuration changes.
+   */
+  protected bool $strictConfigSchema = FALSE;
+
+  /**
    * Ensures buildForm uses saved orphan data.
    */
   public function testCronResultsUsedInForm() {

--- a/tests/src/Kernel/FileIndexHooksTest.php
+++ b/tests/src/Kernel/FileIndexHooksTest.php
@@ -19,6 +19,11 @@ class FileIndexHooksTest extends KernelTestBase {
   protected static $modules = ['system', 'user', 'file', 'file_adoption'];
 
   /**
+   * Disable strict schema checks for configuration changes.
+   */
+  protected bool $strictConfigSchema = FALSE;
+
+  /**
    * Verifies insert and delete hooks update the managed flag.
    */
   public function testManagedFlagUpdates() {

--- a/tests/src/Kernel/FileScannerTest.php
+++ b/tests/src/Kernel/FileScannerTest.php
@@ -19,6 +19,11 @@ class FileScannerTest extends KernelTestBase {
   protected static $modules = ['system', 'user', 'file', 'file_adoption'];
 
   /**
+   * Disable strict schema checks for configuration changes.
+   */
+  protected bool $strictConfigSchema = FALSE;
+
+  /**
    * Tests ignore pattern parsing and scanning lists.
    */
   public function testScanning() {

--- a/tests/src/Kernel/RecordOrphansTest.php
+++ b/tests/src/Kernel/RecordOrphansTest.php
@@ -19,6 +19,11 @@ class RecordOrphansTest extends KernelTestBase {
   protected static $modules = ['system', 'user', 'file', 'file_adoption'];
 
   /**
+   * Disable strict schema checks for configuration changes.
+   */
+  protected bool $strictConfigSchema = FALSE;
+
+  /**
    * Ensures recordOrphans scans all files even when a limit is provided.
    */
   public function testRecordOrphansLimit() {


### PR DESCRIPTION
## Summary
- disable strict schema checking for all Kernel tests

## Testing
- `php -l tests/src/Kernel/DirectoryDepthTest.php`
- `php -l tests/src/Kernel/FileAdoptionCronTest.php`
- `php -l tests/src/Kernel/FileAdoptionFormTest.php`
- `php -l tests/src/Kernel/FileIndexHooksTest.php`
- `php -l tests/src/Kernel/FileScannerTest.php`
- `php -l tests/src/Kernel/RecordOrphansTest.php`
- `vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6873c91f0b5c8331aa34356b42042828