### PR TITLE
Update adoption timestamp

### DIFF
--- a/config/schema/file_adoption.schema.yml
+++ b/config/schema/file_adoption.schema.yml
@@ -11,6 +11,9 @@ file_adoption.settings:
     items_per_run:
       type: integer
       label: 'Items processed per cron run'
+    scan_interval_hours:
+      type: integer
+      label: 'Full-scan interval (hours)'
     ignore_symlinks:
       type: boolean
       label: 'Ignore Symlinks'

--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -132,7 +132,11 @@ class FileScanner {
       $this->db->delete('file_adoption_index')->condition('uri', $uri)->execute();
       return;
     }
+    $mtime = filemtime($real);
     $f = File::create(['uri' => $uri, 'uid' => 0, 'status' => 0]);
+    if ($mtime !== FALSE) {
+      $f->setCreatedTime($mtime);
+    }
     $f->save();
     $this->db->update('file_adoption_index')
       ->fields(['is_managed' => 1])


### PR DESCRIPTION
## Summary
- set file entity created time during adoption
- document scan interval in configuration schema

## Testing
- `phpunit tests` *(fails: Class "Drupal\KernelTests\KernelTestBase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c91b965c83318305bd8092b4154b