### PR TITLE
Update tests to use file_adoption_index

### DIFF
--- a/file_adoption.install
+++ b/file_adoption.install
@@ -84,12 +84,7 @@ function file_adoption_update_10012(): string {
   $db     = \Drupal::database();
   $schema = $db->schema();
 
-  // 1 – drop the obsolete orphan table if it still exists.
-  if ($schema->tableExists('file_adoption_orphans')) {
-    $schema->dropTable('file_adoption_orphans');
-  }
-
-  // 2 – rename legacy columns ‘ignored’ → ‘is_ignored’, ‘managed’ → ‘is_managed’.
+  // 1 – rename legacy columns ‘ignored’ → ‘is_ignored’, ‘managed’ → ‘is_managed’.
   $spec = [
     'type'     => 'int',
     'size'     => 'tiny',

--- a/tests/src/Kernel/FileAdoptionCronTest.php
+++ b/tests/src/Kernel/FileAdoptionCronTest.php
@@ -64,7 +64,9 @@ class FileAdoptionCronTest extends KernelTestBase {
     // When symlinks are processed, two orphans are recorded.
     file_adoption_cron();
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();
@@ -75,7 +77,9 @@ class FileAdoptionCronTest extends KernelTestBase {
     // The original record remains and the real file entry is updated.
     file_adoption_cron();
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();
@@ -100,7 +104,9 @@ class FileAdoptionCronTest extends KernelTestBase {
 
     file_adoption_cron();
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();
@@ -110,7 +116,9 @@ class FileAdoptionCronTest extends KernelTestBase {
 
     file_adoption_cron();
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();
@@ -135,7 +143,9 @@ class FileAdoptionCronTest extends KernelTestBase {
 
     file_adoption_cron();
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();
@@ -160,7 +170,9 @@ class FileAdoptionCronTest extends KernelTestBase {
 
     file_adoption_cron();
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();
@@ -170,7 +182,9 @@ class FileAdoptionCronTest extends KernelTestBase {
 
     file_adoption_cron();
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();
@@ -195,7 +209,9 @@ class FileAdoptionCronTest extends KernelTestBase {
 
     file_adoption_cron();
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();
@@ -205,7 +221,9 @@ class FileAdoptionCronTest extends KernelTestBase {
 
     file_adoption_cron();
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -63,7 +63,9 @@ class FileAdoptionFormTest extends KernelTestBase {
     $this->assertEmpty($form_state->get('scan_results'));
 
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();
@@ -107,7 +109,9 @@ class FileAdoptionFormTest extends KernelTestBase {
     $this->assertEquals(1, $count);
 
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();
@@ -144,17 +148,17 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $records = $this->container->get('database')
       ->select('file_adoption_index', 'fi')
-      ->fields('fi', ['uri', 'ignored', 'managed'])
+      ->fields('fi', ['uri', 'is_ignored', 'is_managed'])
       ->execute()
       ->fetchAllAssoc('uri');
 
     $this->assertArrayHasKey('public://tmp1/keep.txt', $records);
-    $this->assertEquals(0, $records['public://tmp1/keep.txt']->ignored);
-    $this->assertEquals(1, $records['public://tmp1/keep.txt']->managed);
-    $this->assertEquals(1, $records['public://tmp1/skip.log']->ignored);
-    $this->assertEquals(0, $records['public://tmp1/skip.log']->managed);
-    $this->assertEquals(1, $records['public://tmp2/only.txt']->ignored);
-    $this->assertEquals(0, $records['public://tmp2/only.txt']->managed);
+    $this->assertEquals(0, $records['public://tmp1/keep.txt']->is_ignored);
+    $this->assertEquals(1, $records['public://tmp1/keep.txt']->is_managed);
+    $this->assertEquals(1, $records['public://tmp1/skip.log']->is_ignored);
+    $this->assertEquals(0, $records['public://tmp1/skip.log']->is_managed);
+    $this->assertEquals(1, $records['public://tmp2/only.txt']->is_ignored);
+    $this->assertEquals(0, $records['public://tmp2/only.txt']->is_managed);
 
     $form_state = new FormState();
     $form_object = new FileAdoptionForm(
@@ -311,9 +315,11 @@ class FileAdoptionFormTest extends KernelTestBase {
     $this->assertStringContainsString('keep.log', $markup);
     $this->assertStringContainsString('skip.txt', $markup);
 
-    // The orphan table should now contain both files.
+    // The index should now contain both files as unmanaged.
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();
@@ -333,9 +339,11 @@ class FileAdoptionFormTest extends KernelTestBase {
     $scanner = $this->container->get('file_adoption.file_scanner');
     $scanner->buildIndex();
 
-    // Ensure the orphan table starts empty.
+    // Ensure the index starts with no unmanaged files.
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();
@@ -353,7 +361,9 @@ class FileAdoptionFormTest extends KernelTestBase {
     $this->assertStringContainsString('index.txt', $markup);
 
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();

--- a/tests/src/Kernel/FileScannerTest.php
+++ b/tests/src/Kernel/FileScannerTest.php
@@ -46,7 +46,9 @@ class FileScannerTest extends KernelTestBase {
     $this->assertEquals(['public://example.txt'], $results['to_manage']);
 
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();
@@ -234,7 +236,9 @@ class FileScannerTest extends KernelTestBase {
     $scanner->scanWithLists();
 
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();
@@ -244,7 +248,9 @@ class FileScannerTest extends KernelTestBase {
     $scanner->adoptFile('public://orphan.txt');
 
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();
@@ -312,15 +318,15 @@ class FileScannerTest extends KernelTestBase {
 
     $records = $this->container->get('database')
       ->select('file_adoption_index', 'fi')
-      ->fields('fi', ['uri', 'ignored', 'managed'])
+      ->fields('fi', ['uri', 'is_ignored', 'is_managed'])
       ->execute()
       ->fetchAllAssoc('uri');
 
     $this->assertEquals(['public://keep.txt', 'public://skip.log'], array_keys($records));
-    $this->assertEquals(0, $records['public://keep.txt']->ignored);
-    $this->assertEquals(1, $records['public://keep.txt']->managed);
-    $this->assertEquals(1, $records['public://skip.log']->ignored);
-    $this->assertEquals(0, $records['public://skip.log']->managed);
+    $this->assertEquals(0, $records['public://keep.txt']->is_ignored);
+    $this->assertEquals(1, $records['public://keep.txt']->is_managed);
+    $this->assertEquals(1, $records['public://skip.log']->is_ignored);
+    $this->assertEquals(0, $records['public://skip.log']->is_managed);
   }
 
   /**

--- a/tests/src/Kernel/RecordOrphansTest.php
+++ b/tests/src/Kernel/RecordOrphansTest.php
@@ -35,7 +35,9 @@ class RecordOrphansTest extends KernelTestBase {
     $scanner->recordOrphans(2);
 
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();
@@ -54,7 +56,9 @@ class RecordOrphansTest extends KernelTestBase {
     file_put_contents("$public/first.txt", 'a');
     file_adoption_cron();
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();
@@ -64,7 +68,9 @@ class RecordOrphansTest extends KernelTestBase {
     file_put_contents("$public/second.txt", 'b');
     file_adoption_cron();
     $count = $this->container->get('database')
-      ->select('file_adoption_orphans')
+      ->select('file_adoption_index')
+      ->condition('is_managed', 0)
+      ->condition('is_ignored', 0)
       ->countQuery()
       ->execute()
       ->fetchField();


### PR DESCRIPTION
## Summary
- remove leftover orphan table handling from update hook
- look up unmanaged files via `file_adoption_index` in tests
- expect new column names when checking index records

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6873c9171e64833199474230c0e28873