### PR TITLE
Add alias for file scanner service

### DIFF
--- a/file_adoption.services.yml
+++ b/file_adoption.services.yml
@@ -6,6 +6,8 @@ services:
       - '@database'
       - '@config.factory'
       - '@logger.channel.file_adoption'
+  file_adoption.file_scanner:
+    alias: 'file_adoption.scanner'
   logger.channel.file_adoption:
     parent: logger.channel_base
     arguments: ['file_adoption']


### PR DESCRIPTION
## Summary
- add `file_adoption.file_scanner` alias for existing `file_adoption.scanner`

## Testing
- `../vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6873f4f15d6483318c586e60d05cc776