### PR TITLE
Update file adoption defaults

### DIFF
--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -2,6 +2,8 @@ items_per_run: 20
 scan_interval_hours: 24
 enable_adoption: false
 ignore_symlinks: true
+directory_depth: 9
+cron_frequency: daily
 verbose_logging: false
 ignore_patterns: |
   public://css/.*

--- a/file_adoption.settings.yml
+++ b/file_adoption.settings.yml
@@ -1,6 +1,0 @@
-items_per_run: 20
-scan_interval_hours: 24
-enable_adoption: false
-ignore_symlinks: true
-verbose_logging: false
-ignore_patterns: ''


### PR DESCRIPTION
## Summary
- add `directory_depth` and `cron_frequency` defaults
- remove obsolete root-level configuration

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6873f5e2f4888331b2ead923dd9edf6f