### PR TITLE
Remove leftover debug note

### DIFF
--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -51,7 +51,7 @@ class FileScanner {
       $depth = substr_count($rel, '/');
 
       $this->db->merge('file_adoption_index')
-        ->key('uri', $uri)                     // << fixed here
+        ->key('uri', $uri)
         ->fields([
           'timestamp'       => \Drupal::time()->getCurrentTime(),
           'is_ignored'      => (int) $this->isIgnored($rel, $patterns),


### PR DESCRIPTION
## Summary
- clean up code by removing `// << fixed here` comment from `FileScanner`

## Testing
- `composer validate --no-check-all`
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6873f5e464d08331b956604434c9f87c