### PR TITLE
Update tests for renamed scanner service

### DIFF
--- a/tests/src/Kernel/DirectoryDepthTest.php
+++ b/tests/src/Kernel/DirectoryDepthTest.php
@@ -38,7 +38,7 @@ class DirectoryDepthTest extends KernelTestBase {
     file_put_contents("$public/level1/level2/level3/file.txt", 'c');
 
     /** @var FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
     $scanner->scanPublicFiles();
 
     $this->config('file_adoption.settings')->set('directory_depth', 1)->save();

--- a/tests/src/Kernel/FileAdoptionCronTest.php
+++ b/tests/src/Kernel/FileAdoptionCronTest.php
@@ -41,7 +41,7 @@ class FileAdoptionCronTest extends KernelTestBase {
     // First cron run should adopt only one file.
     file_adoption_cron();
     /** @var FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
     $scanner->scanPublicFiles();
     $count = $this->container->get('database')
       ->select('file_adoption_index')

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -136,7 +136,7 @@ class FileAdoptionFormTest extends KernelTestBase {
     $this->config('file_adoption.settings')->set('ignore_patterns', "*.log\ntmp2/*")->save();
 
     /** @var \Drupal\file_adoption\FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
     $scanner->scanPublicFiles();
 
     $records = $this->container->get('database')
@@ -185,7 +185,7 @@ class FileAdoptionFormTest extends KernelTestBase {
     // Update ignore patterns and rebuild the index without clearing orphans.
     $this->config('file_adoption.settings')->set('ignore_patterns', '*.log')->save();
     /** @var \Drupal\file_adoption\FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
     $scanner->scanPublicFiles();
 
     $form_state = new FormState();
@@ -212,7 +212,7 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $this->config('file_adoption.settings')->set('ignore_patterns', '*.txt')->save();
     /** @var \Drupal\file_adoption\FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
     $scanner->scanPublicFiles();
 
     $form_state = new FormState();
@@ -246,7 +246,7 @@ class FileAdoptionFormTest extends KernelTestBase {
     $this->config('file_adoption.settings')->set('items_per_run', 2)->save();
 
     /** @var \Drupal\file_adoption\FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
     $scanner->scanPublicFiles();
 
     $form_state = new FormState();
@@ -277,7 +277,7 @@ class FileAdoptionFormTest extends KernelTestBase {
     // Remove ignore patterns and rebuild the index.
     $this->config('file_adoption.settings')->set('ignore_patterns', '')->save();
     /** @var \Drupal\file_adoption\FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
     $scanner->scanPublicFiles();
 
     $form_state = new FormState();
@@ -309,7 +309,7 @@ class FileAdoptionFormTest extends KernelTestBase {
     file_put_contents("$public/index.txt", 'x');
 
     /** @var \Drupal\file_adoption\FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
     $scanner->scanPublicFiles();
 
     // Ensure no orphans are recorded initially.
@@ -352,7 +352,7 @@ class FileAdoptionFormTest extends KernelTestBase {
     file_put_contents("$public/level1/level2/level3/file.txt", 'c');
 
     /** @var \Drupal\file_adoption\FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
     $scanner->scanPublicFiles();
 
     $this->config('file_adoption.settings')->set('directory_depth', 1)->save();

--- a/tests/src/Kernel/FileScannerTest.php
+++ b/tests/src/Kernel/FileScannerTest.php
@@ -85,7 +85,7 @@ class FileScannerTest extends KernelTestBase {
     $this->config('file_adoption.settings')->set('ignore_patterns', "css/*")->save();
 
     /** @var \Drupal\file_adoption\FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
 
     $patterns = $scanner->getIgnorePatterns();
     $this->assertEquals(['css/*'], $patterns);
@@ -120,7 +120,7 @@ class FileScannerTest extends KernelTestBase {
     file_put_contents("$public/two.txt", '2');
 
     /** @var FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
 
     $scanner->scanPublicFiles();
     $scanner->adoptUnmanaged(1);
@@ -156,7 +156,7 @@ class FileScannerTest extends KernelTestBase {
     file_put_contents("$public/three.txt", '3');
 
     /** @var FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
 
     $scanner->scanPublicFiles();
     $scanner->adoptUnmanaged(2);
@@ -191,7 +191,7 @@ class FileScannerTest extends KernelTestBase {
       ->save();
 
     /** @var FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
 
     $scanner->scanPublicFiles();
     $count = $this->container->get('database')
@@ -236,7 +236,7 @@ class FileScannerTest extends KernelTestBase {
     file_put_contents("$public/example.txt", 'foo');
 
     /** @var FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
 
     // Build the index then create a managed file entity.
     $scanner->scanPublicFiles();
@@ -273,7 +273,7 @@ class FileScannerTest extends KernelTestBase {
     touch($path, $mtime);
 
     /** @var FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
 
     $scanner->scanPublicFiles();
     $scanner->adoptUnmanaged();
@@ -319,7 +319,7 @@ class FileScannerTest extends KernelTestBase {
     $this->config('file_adoption.settings')->set('ignore_patterns', '*.txt')->save();
 
     /** @var FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
 
     $scanner->scanPublicFiles();
     $scanner->adoptUnmanaged();
@@ -343,7 +343,7 @@ class FileScannerTest extends KernelTestBase {
     file_put_contents("$public/orphan.txt", 'x');
 
     /** @var FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
 
     // Record the orphan file.
     $scanner->scanPublicFiles();
@@ -388,7 +388,7 @@ class FileScannerTest extends KernelTestBase {
     $file->save();
 
     /** @var FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
 
     $scanner->scanPublicFiles();
     $scanner->adoptUnmanaged();
@@ -424,7 +424,7 @@ class FileScannerTest extends KernelTestBase {
     $this->config('file_adoption.settings')->set('ignore_patterns', '*.log')->save();
 
     /** @var FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
 
     $scanner->scanPublicFiles();
 
@@ -454,7 +454,7 @@ class FileScannerTest extends KernelTestBase {
     $this->config('file_adoption.settings')->set('ignore_patterns', '*test*')->save();
 
     /** @var FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
 
     $scanner->scanPublicFiles();
     $orphans = $this->container->get('database')
@@ -478,7 +478,7 @@ class FileScannerTest extends KernelTestBase {
     file_put_contents("$public/two.txt", '2');
 
     /** @var FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
 
     $scanner->scanPublicFiles();
     $first = $this->container->get('database')

--- a/tests/src/Kernel/RecordOrphansTest.php
+++ b/tests/src/Kernel/RecordOrphansTest.php
@@ -7,7 +7,7 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\file_adoption\FileScanner;
 
 /**
- * Tests the recordOrphans() method.
+ * Tests the scanPublicFiles() method.
  *
  * @group file_adoption
  */
@@ -24,7 +24,7 @@ class RecordOrphansTest extends KernelTestBase {
   protected bool $strictConfigSchema = FALSE;
 
   /**
-   * Ensures recordOrphans scans all files even when a limit is provided.
+   * Ensures scanPublicFiles scans all files even when a limit is provided.
    */
   public function testRecordOrphansLimit() {
     $public = $this->container->get('file_system')->getTempDirectory();
@@ -35,7 +35,7 @@ class RecordOrphansTest extends KernelTestBase {
     file_put_contents("$public/three.txt", '3');
 
     /** @var FileScanner $scanner */
-    $scanner = $this->container->get('file_adoption.file_scanner');
+    $scanner = $this->container->get('file_adoption.scanner');
 
     $scanner->scanPublicFiles();
 


### PR DESCRIPTION
## Summary
- use `file_adoption.scanner` service in kernel tests
- refresh RecordOrphansTest comments to mention `scanPublicFiles`

## Testing
- `vendor/bin/phpunit tests/src/Kernel --bootstrap vendor/autoload.php` *(fails: Class "Drupal\KernelTests\KernelTestBase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873f726fec883319a23d534cfe62edb