### PR TITLE
Add initial scan state flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ for files that are not tracked by Drupal's `file_managed` table. Identified
    or by copying the module into `modules/custom`.
 2. Enable the module from the **Extend** page or with Drush:
    ```bash
-   drush en file_adoption
-   ```
+ drush en file_adoption
+  ```
+   The first cron run after installation automatically performs a full scan of
+   `public://`. Run `drush cron` if you want results immediately.
 3. Navigate to **Administration → Reports → File Adoption** (`/admin/reports/file-adoption`)
    to configure settings or review the most recent scan results. The page no
    longer runs a scan automatically.
@@ -60,7 +62,8 @@ Changes are stored in `file_adoption.settings`.
 
 ## Cron Integration
 
-Scanning occurs exclusively during cron runs. The `Cron Frequency` setting
+Scanning occurs exclusively during cron runs. Upon installation a state flag
+causes the next cron run to perform an immediate full scan. The `Cron Frequency` setting
 controls how often `hook_cron()` invokes the `FileScanner` service. Each run
 records its totals to state so the configuration page can report the last
 execution. When **Enable Adoption** is disabled the run simply updates the

--- a/file_adoption.install
+++ b/file_adoption.install
@@ -67,6 +67,13 @@ function file_adoption_schema(): array {
 }
 
 /**
+ * Implements hook_install().
+ */
+function file_adoption_install(): void {
+  \Drupal::state()->set('file_adoption.needs_initial_scan', TRUE);
+}
+
+/**
  * Implements hook_uninstall().
  */
 function file_adoption_uninstall(): void {

--- a/file_adoption.module
+++ b/file_adoption.module
@@ -17,6 +17,12 @@ function file_adoption_cron(): void {
   $config  = \Drupal::config('file_adoption.settings');
   $state   = \Drupal::state();
 
+  if ($state->get('file_adoption.needs_initial_scan')) {
+    $scanner->scanPublicFiles();
+    $state->set('file_adoption.last_full_scan', \Drupal::time()->getCurrentTime());
+    $state->delete('file_adoption.needs_initial_scan');
+  }
+
   $interval = ((int) ($config->get('scan_interval_hours') ?? 24)) * 3600;
   $last     = (int) $state->get('file_adoption.last_full_scan', 0);
 

--- a/tests/src/Kernel/InitialScanFlagTest.php
+++ b/tests/src/Kernel/InitialScanFlagTest.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace Drupal\Tests\file_adoption\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests that an initial scan is triggered on first cron run.
+ *
+ * @group file_adoption
+ */
+class InitialScanFlagTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'file', 'file_adoption'];
+
+  /**
+   * Disable strict schema checks for configuration changes.
+   */
+  protected bool $strictConfigSchema = FALSE;
+
+  /**
+   * Ensures a scan occurs when the install flag is present.
+   */
+  public function testInitialScanFlag() {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save(TRUE);
+
+    // Install hook should set the flag.
+    $state = $this->container->get('state');
+    $this->assertTrue($state->get('file_adoption.needs_initial_scan'));
+
+    file_put_contents("$public/test.txt", 'x');
+
+    // Force cron to think a full scan recently occurred.
+    $state->set('file_adoption.last_full_scan', REQUEST_TIME);
+
+    // Run cron, which should scan despite the interval because of the flag.
+    file_adoption_cron();
+
+    $count = $this->container->get('database')
+      ->select('file_adoption_index')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(1, $count);
+
+    // Flag should be cleared after the run.
+    $this->assertNull($state->get('file_adoption.needs_initial_scan'));
+  }
+}


### PR DESCRIPTION
## Summary
- add `file_adoption_install()` hook to set a state flag requesting a full scan
- run immediate scan on next cron run when flag exists and clear it afterward
- document behavior in README
- test new install flag logic

## Testing
- `php -l file_adoption.install`
- `php -l file_adoption.module`
- `php -l tests/src/Kernel/InitialScanFlagTest.php`
- `phpunit tests/src/Kernel/InitialScanFlagTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873fc5a29e4833188ae3ca2416979ad