### PR TITLE
Clear state on uninstall

### DIFF
--- a/file_adoption.install
+++ b/file_adoption.install
@@ -75,6 +75,11 @@ function file_adoption_uninstall(): void {
     $db->schema()->dropTable('file_adoption_index');
   }
   \Drupal::configFactory()->getEditable('file_adoption.settings')->delete();
+
+  $state = \Drupal::state();
+  foreach (['file_adoption.last_full_scan', 'file_adoption.last_cron'] as $key) {
+    $state->delete($key);
+  }
 }
 
 /**

--- a/tests/src/Kernel/UninstallStateTest.php
+++ b/tests/src/Kernel/UninstallStateTest.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Drupal\Tests\file_adoption\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests that uninstall cleans up state.
+ *
+ * @group file_adoption
+ */
+class UninstallStateTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'file', 'file_adoption'];
+
+  /**
+   * Disable strict schema checks for configuration changes.
+   */
+  protected bool $strictConfigSchema = FALSE;
+
+  /**
+   * Ensures state values are removed on uninstall.
+   */
+  public function testStateRemovedOnUninstall() {
+    $state = \Drupal::state();
+    $state->set('file_adoption.last_full_scan', 123);
+    $state->set('file_adoption.last_cron', 456);
+
+    \Drupal::service('module_installer')->uninstall(['file_adoption']);
+
+    $this->assertNull($state->get('file_adoption.last_full_scan'));
+    $this->assertNull($state->get('file_adoption.last_cron'));
+  }
+}


### PR DESCRIPTION
## Summary
- delete state keys during uninstall
- test uninstall state cleanup

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6873fc5b2ef883318eff560381aa4866