### PR TITLE
Implement cron frequency scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,11 @@ Changes are stored in `file_adoption.settings`.
 ## Cron Integration
 
 Scanning occurs exclusively during cron runs. The `Cron Frequency` setting
-controls how often `hook_cron()` invokes the `FileScanner` service. Each run
-records its totals to state so the configuration page can report the last
-execution. When **Enable Adoption** is disabled the run simply updates the
-`file_adoption_index` table with any discovered orphans. When adoption is
-enabled, matching files are registered immediately. Every cron run rebuilds the
-`file_adoption_index` table so the most current data is always available.
+determines how often file adoption tasks run. Each execution scans the public
+files directory and, when enabled, adopts orphaned files. Results are recorded
+to state so the configuration page can report the last run. Every cron run
+rebuilds the `file_adoption_index` table so the most current data is always
+available.
 
 ## Running Tests
 

--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -1,5 +1,4 @@
 items_per_run: 20
-scan_interval_hours: 24
 enable_adoption: false
 ignore_symlinks: true
 directory_depth: 9

--- a/config/schema/file_adoption.schema.yml
+++ b/config/schema/file_adoption.schema.yml
@@ -11,9 +11,6 @@ file_adoption.settings:
     items_per_run:
       type: integer
       label: 'Items processed per cron run'
-    scan_interval_hours:
-      type: integer
-      label: 'Full-scan interval (hours)'
     ignore_symlinks:
       type: boolean
       label: 'Ignore Symlinks'

--- a/file_adoption.module
+++ b/file_adoption.module
@@ -17,16 +17,25 @@ function file_adoption_cron(): void {
   $config  = \Drupal::config('file_adoption.settings');
   $state   = \Drupal::state();
 
-  $interval = ((int) ($config->get('scan_interval_hours') ?? 24)) * 3600;
-  $last     = (int) $state->get('file_adoption.last_full_scan', 0);
+  $now   = \Drupal::time()->getCurrentTime();
+  $last  = (int) $state->get('file_adoption.last_cron', 0);
+  $freq  = $config->get('cron_frequency') ?? 'daily';
 
-  if (\Drupal::time()->getCurrentTime() - $last >= $interval) {
+  $map = [
+    'hourly'  => 3600,
+    'daily'   => 86400,
+    'weekly'  => 604800,
+    'monthly' => 2592000,
+    'yearly'  => 31536000,
+  ];
+  $run = ($freq === 'every') || ($now - $last >= ($map[$freq] ?? 0));
+
+  if ($run) {
     $scanner->scanPublicFiles();
-    $state->set('file_adoption.last_full_scan', \Drupal::time()->getCurrentTime());
-  }
-
-  if ($config->get('enable_adoption')) {
-    $scanner->adoptUnmanaged((int) ($config->get('items_per_run') ?? 20));
+    if ($config->get('enable_adoption')) {
+      $scanner->adoptUnmanaged((int) ($config->get('items_per_run') ?? 20));
+    }
+    $state->set('file_adoption.last_cron', $now);
   }
 }
 

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -42,11 +42,18 @@ class FileAdoptionForm extends FormBase implements ContainerInjectionInterface {
       '#title' => $this->t('Settings'),
       '#open'  => TRUE,
     ];
-    $form['settings']['scan_interval_hours'] = [
-      '#type'          => 'number',
-      '#title'         => $this->t('Full‑scan interval (hours)'),
-      '#default_value' => (int) ($config->get('scan_interval_hours') ?? 24),
-      '#min'           => 1,
+    $form['settings']['cron_frequency'] = [
+      '#type'    => 'select',
+      '#title'   => $this->t('Cron frequency'),
+      '#options' => [
+        'every'  => $this->t('Every run'),
+        'hourly' => $this->t('Hourly'),
+        'daily'  => $this->t('Daily'),
+        'weekly' => $this->t('Weekly'),
+        'monthly'=> $this->t('Monthly'),
+        'yearly' => $this->t('Yearly'),
+      ],
+      '#default_value' => $config->get('cron_frequency') ?? 'daily',
     ];
     $form['settings']['enable_adoption'] = [
       '#type'          => 'checkbox',
@@ -141,7 +148,7 @@ class FileAdoptionForm extends FormBase implements ContainerInjectionInterface {
   /* ------------------------------------------------------------------ */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     $this->configFactory()->getEditable('file_adoption.settings')
-      ->set('scan_interval_hours', (int) $form_state->getValue('scan_interval_hours'))
+      ->set('cron_frequency',     $form_state->getValue('cron_frequency'))
       ->set('enable_adoption',    (bool) $form_state->getValue('enable_adoption'))
       ->set('items_per_run',       (int) $form_state->getValue('items_per_run'))
       ->set('ignore_patterns',     trim((string) $form_state->getValue('patterns')))


### PR DESCRIPTION
## Summary
- support cron_frequency scheduling and remove old scan_interval_hours
- update config schema and defaults
- tweak admin form and README

## Testing
- `php -l file_adoption.module`
- `php -l src/Form/FileAdoptionForm.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873fc5dabf4833198409e82e0fea5f6