### PR TITLE
Remove unused cron_frequency config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ The configuration form offers the following options:
 - **Directory Depth** – Maximum directory depth displayed under "Directories".
   Directories deeper than this setting are omitted from the summary but files
   within them can still be adopted. Valid range is 1–9 and the default is 9.
-- **Cron Frequency** – How often cron should run file adoption tasks. Options
-  include every cron run, hourly, daily, weekly, monthly, or yearly.
+- **Full-scan interval (hours)** – Number of hours between automatic full scans.
+    Set to `0` to run on every cron run. The default is 24 hours.
 - **Verbose Logging** – When enabled, additional debug information is written to
   the log during scans and adoption. This is off by default. Adoption success
   messages are only recorded when verbose logging is enabled. When enabled,
@@ -79,7 +79,7 @@ Changes are stored in `file_adoption.settings`.
 ## Cron Integration
 
 Scanning occurs exclusively during cron runs. Upon installation a state flag
-causes the next cron run to perform an immediate full scan. The `Cron Frequency` setting
+causes the next cron run to perform an immediate full scan. The *Full-scan interval* setting
 controls how often `hook_cron()` invokes the `FileScanner` service. Each run
 records its totals to state so the configuration page can report the last
 execution. When **Enable Adoption** is disabled the run simply updates the

--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -3,7 +3,6 @@ scan_interval_hours: 24
 enable_adoption: false
 ignore_symlinks: true
 directory_depth: 9
-cron_frequency: daily
 verbose_logging: false
 ignore_patterns: |
   public://css/.*

--- a/config/schema/file_adoption.schema.yml
+++ b/config/schema/file_adoption.schema.yml
@@ -23,9 +23,6 @@ file_adoption.settings:
       range:
         min: 1
         max: 9
-    cron_frequency:
-      type: string
-      label: 'Cron frequency'
     verbose_logging:
       type: boolean
       label: 'Verbose Logging'

--- a/tests/src/Kernel/FileAdoptionCronTest.php
+++ b/tests/src/Kernel/FileAdoptionCronTest.php
@@ -116,10 +116,10 @@ class FileAdoptionCronTest extends KernelTestBase {
 
     $this->config('file_adoption.settings')
       ->set('enable_adoption', FALSE)
-      ->set('cron_frequency', 'weekly')
+      ->set('scan_interval_hours', 168)
       ->save();
 
-    \Drupal::state()->set('file_adoption.last_cron', REQUEST_TIME);
+    \Drupal::state()->set('file_adoption.last_full_scan', REQUEST_TIME);
 
     file_adoption_cron();
     $count = $this->container->get('database')
@@ -131,7 +131,7 @@ class FileAdoptionCronTest extends KernelTestBase {
       ->fetchField();
     $this->assertEquals(0, $count);
 
-    \Drupal::state()->set('file_adoption.last_cron', REQUEST_TIME - 604800 - 1);
+    \Drupal::state()->set('file_adoption.last_full_scan', REQUEST_TIME - 604800 - 1);
 
     file_adoption_cron();
     $count = $this->container->get('database')
@@ -155,10 +155,10 @@ class FileAdoptionCronTest extends KernelTestBase {
 
     $this->config('file_adoption.settings')
       ->set('enable_adoption', FALSE)
-      ->set('cron_frequency', 'every')
+      ->set('scan_interval_hours', 0)
       ->save();
 
-    \Drupal::state()->set('file_adoption.last_cron', REQUEST_TIME);
+    \Drupal::state()->set('file_adoption.last_full_scan', REQUEST_TIME);
 
     file_adoption_cron();
     $count = $this->container->get('database')
@@ -182,10 +182,10 @@ class FileAdoptionCronTest extends KernelTestBase {
 
     $this->config('file_adoption.settings')
       ->set('enable_adoption', FALSE)
-      ->set('cron_frequency', 'monthly')
+      ->set('scan_interval_hours', 720)
       ->save();
 
-    \Drupal::state()->set('file_adoption.last_cron', REQUEST_TIME);
+    \Drupal::state()->set('file_adoption.last_full_scan', REQUEST_TIME);
 
     file_adoption_cron();
     $count = $this->container->get('database')
@@ -197,7 +197,7 @@ class FileAdoptionCronTest extends KernelTestBase {
       ->fetchField();
     $this->assertEquals(0, $count);
 
-    \Drupal::state()->set('file_adoption.last_cron', REQUEST_TIME - 2592000 - 1);
+    \Drupal::state()->set('file_adoption.last_full_scan', REQUEST_TIME - 2592000 - 1);
 
     file_adoption_cron();
     $count = $this->container->get('database')
@@ -221,10 +221,10 @@ class FileAdoptionCronTest extends KernelTestBase {
 
     $this->config('file_adoption.settings')
       ->set('enable_adoption', FALSE)
-      ->set('cron_frequency', 'yearly')
+      ->set('scan_interval_hours', 8760)
       ->save();
 
-    \Drupal::state()->set('file_adoption.last_cron', REQUEST_TIME);
+    \Drupal::state()->set('file_adoption.last_full_scan', REQUEST_TIME);
 
     file_adoption_cron();
     $count = $this->container->get('database')
@@ -236,7 +236,7 @@ class FileAdoptionCronTest extends KernelTestBase {
       ->fetchField();
     $this->assertEquals(0, $count);
 
-    \Drupal::state()->set('file_adoption.last_cron', REQUEST_TIME - 31536000 - 1);
+    \Drupal::state()->set('file_adoption.last_full_scan', REQUEST_TIME - 31536000 - 1);
 
     file_adoption_cron();
     $count = $this->container->get('database')


### PR DESCRIPTION
## Summary
- drop `cron_frequency` from default config and schema
- describe the numeric "Full-scan interval" setting in README
- adjust cron tests to use `scan_interval_hours`

## Testing
- `phpunit -c core tests/src/Kernel/FileAdoptionCronTest.php` *(fails: Could not read "core")*
- `phpunit tests/src/Kernel/FileAdoptionCronTest.php` *(fails: Class "Drupal\KernelTests\KernelTestBase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873fa902edc8331b3a002c29483b26e