### PR TITLE
Add adopt temporary checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The configuration form offers the following options:
 - **Items per cron run** – Maximum number of files adopted or displayed per
   scan or cron run. All discovered orphans are saved regardless of this
   limit. Defaults to 20.
+- **Adopt as Temporary** – When checked, newly adopted files are saved as
+  temporary. Unchecked files become permanent immediately.
 - **Ignore Symlinks** – When enabled, symbolic links are skipped during scanning,
   preventing loops or slowdowns caused by symlinks.
   Symlinks discovered during scanning are still listed under the "Symlinks"

--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -1,6 +1,7 @@
 items_per_run: 20
 scan_interval_hours: 24
 enable_adoption: false
+adopt_temporary: true
 ignore_symlinks: true
 directory_depth: 9
 verbose_logging: false

--- a/config/schema/file_adoption.schema.yml
+++ b/config/schema/file_adoption.schema.yml
@@ -8,6 +8,9 @@ file_adoption.settings:
     enable_adoption:
       type: boolean
       label: 'Enable Adoption'
+    adopt_temporary:
+      type: boolean
+      label: 'Adopt as Temporary'
     items_per_run:
       type: integer
       label: 'Items processed per cron run'

--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -133,7 +133,9 @@ class FileScanner {
       return;
     }
     $mtime = filemtime($real);
-    $f = File::create(['uri' => $uri, 'uid' => 0, 'status' => 0]);
+    $temporary = (bool) ($this->configFactory->get('file_adoption.settings')->get('adopt_temporary') ?? TRUE);
+    $status    = $temporary ? 0 : 1;
+    $f = File::create(['uri' => $uri, 'uid' => 0, 'status' => $status]);
     if ($mtime !== FALSE) {
       if (method_exists($f, 'setCreatedTime')) {
         $f->setCreatedTime($mtime);

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -68,6 +68,12 @@ class FileAdoptionForm extends FormBase implements ContainerInjectionInterface {
       '#title'         => $this->t('Enable Adoption'),
       '#default_value' => (bool) ($config->get('enable_adoption') ?? FALSE),
     ];
+    $form['settings']['adopt_temporary'] = [
+      '#type'          => 'checkbox',
+      '#title'         => $this->t('Adopt as Temporary'),
+      '#default_value' => (bool) ($config->get('adopt_temporary') ?? TRUE),
+      '#description'   => $this->t('When checked, newly adopted files are saved as temporary. Unchecked files are permanent.'),
+    ];
     $form['settings']['items_per_run'] = [
       '#type'          => 'number',
       '#title'         => $this->t('Items per adoption batch'),
@@ -158,6 +164,7 @@ class FileAdoptionForm extends FormBase implements ContainerInjectionInterface {
     $this->configFactory()->getEditable('file_adoption.settings')
       ->set('scan_interval_hours', (int) $form_state->getValue('scan_interval_hours'))
       ->set('enable_adoption',    (bool) $form_state->getValue('enable_adoption'))
+      ->set('adopt_temporary',    (bool) $form_state->getValue('adopt_temporary'))
       ->set('items_per_run',       (int) $form_state->getValue('items_per_run'))
       ->set('ignore_patterns',     trim((string) $form_state->getValue('patterns')))
       ->save();

--- a/tests/src/Kernel/FileScannerTest.php
+++ b/tests/src/Kernel/FileScannerTest.php
@@ -32,7 +32,9 @@ class TestScannerNoSetter extends FileScanner {
       return;
     }
     $mtime = filemtime($real);
-    $f = StubFile::create(['uri' => $uri, 'uid' => 0, 'status' => 0]);
+    $temporary = (bool) ($this->configFactory->get('file_adoption.settings')->get('adopt_temporary') ?? TRUE);
+    $status    = $temporary ? 0 : 1;
+    $f = StubFile::create(['uri' => $uri, 'uid' => 0, 'status' => $status]);
     if ($mtime !== FALSE) {
       if (method_exists($f, 'setCreatedTime')) {
         $f->setCreatedTime($mtime);


### PR DESCRIPTION
## Summary
- let site admins choose whether adopted files are temporary or permanent
- default to temporary to preserve prior behaviour
- update the scanner and tests to honour new setting
- document new option in README

## Testing
- `php -l src/Form/FileAdoptionForm.php`
- `php -l src/FileScanner.php`
- `php -l tests/src/Kernel/FileScannerTest.php`
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68740c25b8ec8331813e459ed74fce03