### PR TITLE
Set adopt_temporary default to false

### DIFF
--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -1,7 +1,7 @@
 items_per_run: 20
 scan_interval_hours: 24
 enable_adoption: false
-adopt_temporary: true
+adopt_temporary: false
 ignore_symlinks: true
 directory_depth: 9
 verbose_logging: false

--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -133,7 +133,7 @@ class FileScanner {
       return;
     }
     $mtime = filemtime($real);
-    $temporary = (bool) ($this->configFactory->get('file_adoption.settings')->get('adopt_temporary') ?? TRUE);
+    $temporary = (bool) ($this->configFactory->get('file_adoption.settings')->get('adopt_temporary') ?? FALSE);
     $status    = $temporary ? 0 : 1;
     $f = File::create(['uri' => $uri, 'uid' => 0, 'status' => $status]);
     if ($mtime !== FALSE) {

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -71,7 +71,7 @@ class FileAdoptionForm extends FormBase implements ContainerInjectionInterface {
     $form['settings']['adopt_temporary'] = [
       '#type'          => 'checkbox',
       '#title'         => $this->t('Adopt as Temporary'),
-      '#default_value' => (bool) ($config->get('adopt_temporary') ?? TRUE),
+      '#default_value' => (bool) ($config->get('adopt_temporary') ?? FALSE),
       '#description'   => $this->t('When checked, newly adopted files are saved as temporary. Unchecked files are permanent.'),
     ];
     $form['settings']['items_per_run'] = [

--- a/tests/src/Kernel/FileScannerTest.php
+++ b/tests/src/Kernel/FileScannerTest.php
@@ -32,7 +32,7 @@ class TestScannerNoSetter extends FileScanner {
       return;
     }
     $mtime = filemtime($real);
-    $temporary = (bool) ($this->configFactory->get('file_adoption.settings')->get('adopt_temporary') ?? TRUE);
+    $temporary = (bool) ($this->configFactory->get('file_adoption.settings')->get('adopt_temporary') ?? FALSE);
     $status    = $temporary ? 0 : 1;
     $f = StubFile::create(['uri' => $uri, 'uid' => 0, 'status' => $status]);
     if ($mtime !== FALSE) {


### PR DESCRIPTION
## Summary
- default `adopt_temporary` setting to `false`
- use the new default in the configuration form and scanner
- update tests accordingly

## Testing
- `php -l src/FileScanner.php`
- `php -l src/Form/FileAdoptionForm.php`
- `php -l tests/src/Kernel/FileScannerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_687509af96948331a2980cb07920e356