### PR TITLE
Add full scan button

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ The configuration page also shows details gathered from the most recent scan:
 - **Add to Managed Files** – Displays the files scheduled for adoption. Entries
   are pulled directly from the `file_adoption_index` table after filtering out
   ignored directories and patterns.
+- **Run full scan** – Button at the bottom of the form that immediately
+  executes a full cron-style scan of the public files directory.
 
 Changes are stored in `file_adoption.settings`.
 

--- a/src/Form/FileAdoptionForm.php
+++ b/src/Form/FileAdoptionForm.php
@@ -132,6 +132,11 @@ class FileAdoptionForm extends FormBase implements ContainerInjectionInterface {
       '#type'  => 'submit',
       '#value' => $this->t('Save configuration'),
     ];
+    $form['actions']['scan'] = [
+      '#type'   => 'submit',
+      '#value'  => $this->t('Run full scan'),
+      '#submit' => ['::scanNow'],
+    ];
 
     return $form;
   }
@@ -207,6 +212,15 @@ class FileAdoptionForm extends FormBase implements ContainerInjectionInterface {
     $limit = (int) $this->config('file_adoption.settings')->get('items_per_run') ?? 20;
     $this->scanner->adoptUnmanaged($limit);
     $this->messenger()->addStatus($this->t('Adoption run complete.'));
+    $form_state->setRebuild(TRUE);
+  }
+
+  /* ------------------------------------------------------------------ */
+  public function scanNow(array &$form, FormStateInterface $form_state): void {
+    // Force a scan regardless of the configured interval.
+    \Drupal::state()->set('file_adoption.last_full_scan', 0);
+    file_adoption_cron();
+    $this->messenger()->addStatus($this->t('Full scan complete.'));
     $form_state->setRebuild(TRUE);
   }
 


### PR DESCRIPTION
## Summary
- add a "Run full scan" button to File Adoption form
- document new button in README

## Testing
- `php -l src/Form/FileAdoptionForm.php`
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68750b0f03d4833182d4e35a04a33422