### PR TITLE
Update tests for renamed index flags

### DIFF
--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -138,17 +138,17 @@ class FileAdoptionFormTest extends KernelTestBase {
 
     $records = $this->container->get('database')
       ->select('file_adoption_index', 'fi')
-      ->fields('fi', ['uri', 'ignored', 'managed'])
+      ->fields('fi', ['uri', 'is_ignored', 'is_managed'])
       ->execute()
       ->fetchAllAssoc('uri');
 
     $this->assertArrayHasKey('public://tmp1/keep.txt', $records);
-    $this->assertEquals(0, $records['public://tmp1/keep.txt']->ignored);
-    $this->assertEquals(1, $records['public://tmp1/keep.txt']->managed);
-    $this->assertEquals(1, $records['public://tmp1/skip.log']->ignored);
-    $this->assertEquals(0, $records['public://tmp1/skip.log']->managed);
-    $this->assertEquals(1, $records['public://tmp2/only.txt']->ignored);
-    $this->assertEquals(0, $records['public://tmp2/only.txt']->managed);
+    $this->assertEquals(0, $records['public://tmp1/keep.txt']->is_ignored);
+    $this->assertEquals(1, $records['public://tmp1/keep.txt']->is_managed);
+    $this->assertEquals(1, $records['public://tmp1/skip.log']->is_ignored);
+    $this->assertEquals(0, $records['public://tmp1/skip.log']->is_managed);
+    $this->assertEquals(1, $records['public://tmp2/only.txt']->is_ignored);
+    $this->assertEquals(0, $records['public://tmp2/only.txt']->is_managed);
 
     $form_state = new FormState();
     $form_object = FileAdoptionForm::create($this->container);

--- a/tests/src/Kernel/FileIndexHooksTest.php
+++ b/tests/src/Kernel/FileIndexHooksTest.php
@@ -44,23 +44,23 @@ class FileIndexHooksTest extends KernelTestBase {
 
     $record = $this->container->get('database')
       ->select('file_adoption_index', 'fi')
-      ->fields('fi', ['managed'])
+      ->fields('fi', ['is_managed'])
       ->condition('uri', 'public://example.txt')
       ->execute()
       ->fetchObject();
     $this->assertNotEmpty($record);
-    $this->assertEquals(1, $record->managed);
+    $this->assertEquals(1, $record->is_managed);
 
     // Deleting the entity should set managed to 0 but keep the row.
     $file->delete();
 
     $record = $this->container->get('database')
       ->select('file_adoption_index', 'fi')
-      ->fields('fi', ['managed'])
+      ->fields('fi', ['is_managed'])
       ->condition('uri', 'public://example.txt')
       ->execute()
       ->fetchObject();
     $this->assertNotEmpty($record);
-    $this->assertEquals(0, $record->managed);
+    $this->assertEquals(0, $record->is_managed);
   }
 }


### PR DESCRIPTION
## Summary
- adjust kernel tests for updated index table field names

## Testing
- `../vendor/bin/phpunit -c core modules/custom/file_adoption/tests/src/Kernel` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68758d3d491c83319a00fb82a6b70f4c