### PR TITLE
Add test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,10 @@ enabled, matching files are registered immediately. Every cron run rebuilds the
 
 ## Running Tests
 
-These tests rely on Drupal's core testing environment. Make sure your Drupal
-installation includes the `drupal/core-dev` package. Tests should be executed
-from the Drupal project root so that Drupal's PHPUnit configuration is used.
+These tests rely on Drupal's core testing environment. Install the
+development dependencies with Composer so that `drupal/core-dev` and
+`phpunit/phpunit` are available. Tests should be executed from the Drupal
+project root so that Drupal's PHPUnit configuration is used.
 
 From the module directory you can run:
 

--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,9 @@
   ],
   "require": {
     "php": "^8.1"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9.5 || ^10",
+    "drupal/core-dev": "^10 || ^11"
   }
 }


### PR DESCRIPTION
## Summary
- add phpunit and drupal/core-dev as dev dependencies
- mention composer dev deps in test docs

## Testing
- `composer install --prefer-dist --no-interaction --no-plugins`
- `../vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6875916bf9708331bb2030405e4f6520