### PR TITLE
Update file adoption form behaviour and banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ the `FileScanner` service and the configuration form.
 ## Uninstall
 
 Uninstalling the module removes all configuration and drops the
-`file_adoption_index` table so no leftover data remains.
+`file_adoption_index` table so no leftover data remains. If the table ever
+contains bad data simply uninstall and reinstall the module to rebuild it.
 
 ### v2.0.0 – 2025‑07‑11
 

--- a/src/FileAdoptionManager.php
+++ b/src/FileAdoptionManager.php
@@ -28,17 +28,21 @@ class FileAdoptionManager {
     $config = $this->configFactory->get('file_adoption.settings');
 
     if ($this->state->get('file_adoption.needs_initial_scan')) {
+      $this->state->set('file_adoption.scan_running', TRUE);
       $this->scanner->scanPublicFiles();
       $this->state->set('file_adoption.last_full_scan', $this->time->getCurrentTime());
       $this->state->delete('file_adoption.needs_initial_scan');
+      $this->state->delete('file_adoption.scan_running');
     }
 
     $interval = ((int) ($config->get('scan_interval_hours') ?? 24)) * 3600;
     $last     = (int) $this->state->get('file_adoption.last_full_scan', 0);
 
     if ($interval === 0 || $this->time->getCurrentTime() - $last >= $interval) {
+      $this->state->set('file_adoption.scan_running', TRUE);
       $this->scanner->scanPublicFiles();
       $this->state->set('file_adoption.last_full_scan', $this->time->getCurrentTime());
+      $this->state->delete('file_adoption.scan_running');
     }
 
     if ($config->get('enable_adoption')) {

--- a/tests/src/Kernel/FileAdoptionFormTest.php
+++ b/tests/src/Kernel/FileAdoptionFormTest.php
@@ -44,9 +44,9 @@ class FileAdoptionFormTest extends KernelTestBase {
   }
 
   /**
-   * Ensures buildForm triggers a scan when the index table is empty.
+   * Ensures buildForm does not trigger a scan when the index table is empty.
    */
-  public function testFormAutoScanWhenEmpty() {
+  public function testFormNoScanWhenEmpty() {
     $public = $this->container->get('file_system')->getTempDirectory();
     $this->config('system.file')->set('path.public', $public)->save(TRUE);
 
@@ -63,7 +63,7 @@ class FileAdoptionFormTest extends KernelTestBase {
       ->countQuery()
       ->execute()
       ->fetchField();
-    $this->assertEquals(1, $count);
+    $this->assertEquals(0, $count);
   }
 
   /**


### PR DESCRIPTION
## Summary
- display a warning banner when a file scan is pending or running
- remove automatic scan when the index table is empty
- track scan progress in state during cron runs
- clarify ignore pattern description
- document table removal on uninstall
- adjust test to reflect new behaviour

## Testing
- `composer install` *(fails: no composer.lock)*
- `vendor/bin/phpunit -c core modules/custom/file_adoption` *(fails: core directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876ab121dd48331aeef748c36d82fa9