### PR TITLE
Update default ignore patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,19 @@ The configuration form offers the following options:
   directories such as:
 
   ```
+  /\.
   public://asset_injector/.*
   public://config_.*
   public://css/.*
   public://embed_buttons/.*
+  public://favicon.ico
   public://js/.*
   public://media-icons/.*
+  public://media-youtube/.*
   public://oembed_thumbnails/.*
   public://php/.*
   public://styles/.*
   public://webforms/.*
-  public://\..*
   ```
 
 - Pattern matching is case-insensitive.

--- a/config/install/file_adoption.settings.yml
+++ b/config/install/file_adoption.settings.yml
@@ -6,14 +6,16 @@ ignore_symlinks: true
 directory_depth: 9
 verbose_logging: false
 ignore_patterns: |
+  /\.
   public://asset_injector/.*
   public://config_.*
   public://css/.*
   public://embed_buttons/.*
+  public://favicon.ico
   public://js/.*
   public://media-icons/.*
+  public://media-youtube/.*
   public://oembed_thumbnails/.*
   public://php/.*
   public://styles/.*
   public://webforms/.*
-  public://\..*

--- a/file_adoption.install
+++ b/file_adoption.install
@@ -150,7 +150,7 @@ function file_adoption_update_10012(): string {
  * Update 10013 – seed default ignore patterns if none are set.
  */
 function file_adoption_update_10013(): string {
-  $defaults = "public://asset_injector/.*\npublic://config_.*\npublic://css/.*\npublic://embed_buttons/.*\npublic://js/.*\npublic://media-icons/.*\npublic://oembed_thumbnails/.*\npublic://php/.*\npublic://styles/.*\npublic://webforms/.*\npublic://\\..*";
+  $defaults = "/\\.\npublic://asset_injector/.*\npublic://config_.*\npublic://css/.*\npublic://embed_buttons/.*\npublic://favicon.ico\npublic://js/.*\npublic://media-icons/.*\npublic://media-youtube/.*\npublic://oembed_thumbnails/.*\npublic://php/.*\npublic://styles/.*\npublic://webforms/.*";
 
   $config = \Drupal::configFactory()->getEditable('file_adoption.settings');
   $current = trim((string) $config->get('ignore_patterns'));


### PR DESCRIPTION
## Summary
- update default ignore patterns in settings
- alphabetize and add additional patterns in README
- update database update defaults
- remove `public://\..*` and `public://opac.pac`

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6878fcf7d5d88331afce77baa149fb80