### PR TITLE
Improve managed file lookup

### DIFF
--- a/file_adoption.install
+++ b/file_adoption.install
@@ -178,3 +178,14 @@ function file_adoption_update_10001(): void {
   }
 }
 
+/**
+ * Update 10014 – add index on file_managed.uri.
+ */
+function file_adoption_update_10014(): string {
+  $schema = \Drupal::database()->schema();
+  if (!$schema->indexExists('file_managed', 'file_adoption_uri')) {
+    $schema->addIndex('file_managed', 'file_adoption_uri', ['uri']);
+  }
+  return (string) t('Index added for file_managed.uri.');
+}
+

--- a/src/FileScanner.php
+++ b/src/FileScanner.php
@@ -109,8 +109,10 @@ class FileScanner {
     return true;
   }
 
-  protected array $managedUris      = [];
-  protected bool  $loaded           = FALSE;
+  protected const MANAGED_BATCH = 1000;
+  protected array $managedUris = [];
+  protected int $managedOffset = 0;
+  protected bool $loaded = FALSE;
 
   /** Normalize a file URI for comparison. */
   public function normalizeUri(string $uri): string {
@@ -121,18 +123,44 @@ class FileScanner {
     return preg_replace('#^public:/+#', 'public://', $uri);
   }
 
-  protected function isManaged(string $uri): bool {
-    if (!$this->loaded) {
-      $rows = $this->db->select('file_managed', 'fm')
-        ->fields('fm', ['uri'])
-        ->execute()
-        ->fetchCol();
-      foreach ($rows as $raw) {
-        $this->managedUris[$this->normalizeUri($raw)] = $raw;
-      }
+  protected function loadManagedBatch(): void {
+    $rows = $this->db->select('file_managed', 'fm')
+      ->fields('fm', ['uri'])
+      ->range($this->managedOffset, self::MANAGED_BATCH)
+      ->execute()
+      ->fetchCol();
+    $this->managedOffset += self::MANAGED_BATCH;
+    if (!$rows) {
       $this->loaded = TRUE;
+      return;
     }
-    return isset($this->managedUris[$this->normalizeUri($uri)]);
+    foreach ($rows as $raw) {
+      $this->managedUris[$this->normalizeUri($raw)] = $raw;
+    }
+  }
+
+  protected function isManaged(string $uri): bool {
+    $norm = $this->normalizeUri($uri);
+
+    while (!$this->loaded && !isset($this->managedUris[$norm])) {
+      $this->loadManagedBatch();
+    }
+
+    if (isset($this->managedUris[$norm])) {
+      return TRUE;
+    }
+
+    $relative = ltrim(substr($norm, strlen('public://')), '/');
+    $raw = $this->db->select('file_managed', 'fm')
+      ->fields('fm', ['uri'])
+      ->condition('uri', '%' . $relative, 'LIKE')
+      ->execute()
+      ->fetchField();
+    if ($raw && $this->normalizeUri($raw) === $norm) {
+      $this->managedUris[$norm] = $raw;
+      return TRUE;
+    }
+    return FALSE;
   }
 
   protected function getRawManagedUri(string $uri): ?string {

--- a/tests/src/Kernel/FileScannerTest.php
+++ b/tests/src/Kernel/FileScannerTest.php
@@ -53,6 +53,12 @@ class TestScannerNoSetter extends FileScanner {
   }
 }
 
+class TestScannerExpose extends FileScanner {
+  public function isManagedPublic(string $uri): bool {
+    return $this->isManaged($uri);
+  }
+}
+
 /**
  * Tests the FileScanner service.
  *
@@ -402,6 +408,34 @@ class FileScannerTest extends KernelTestBase {
       ->execute()
       ->fetchField();
     $this->assertEquals(1, $count);
+  }
+
+  /**
+   * Direct isManaged lookup finds managed file URIs.
+   */
+  public function testIsManagedLookup() {
+    $public = $this->container->get('file_system')->getTempDirectory();
+    $this->config('system.file')->set('path.public', $public)->save(TRUE);
+
+    file_put_contents("$public/lookup.txt", 'x');
+
+    $file = \Drupal\file\Entity\File::create([
+      'uri' => 'public:///lookup.txt',
+      'filename' => 'lookup.txt',
+      'status' => 1,
+      'uid' => 0,
+    ]);
+    $file->save();
+
+    $scanner = new TestScannerExpose(
+      $this->container->get('file_system'),
+      $this->container->get('database'),
+      $this->container->get('config.factory'),
+      $this->container->get('logger.channel.file_adoption'),
+      $this->container->get('datetime.time')
+    );
+
+    $this->assertTrue($scanner->isManagedPublic('public://lookup.txt'));
   }
 
   /**


### PR DESCRIPTION
## Summary
- speed up FileScanner::isManaged with on-demand batching
- add index on `file_managed.uri`
- expose isManaged for tests and add a new test

## Testing
- `php -l src/FileScanner.php`
- `php -l tests/src/Kernel/FileScannerTest.php`
- `php -l file_adoption.install`
- `vendor/bin/phpunit tests/src/Kernel/FileScannerTest.php` *(fails: Class "Drupal\file_adoption\FileScanner" not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e320090908331b2a4f5a6b464cb43